### PR TITLE
Add nexus definition option to loaders 

### DIFF
--- a/src/ess/reduce/nexus.py
+++ b/src/ess/reduce/nexus.py
@@ -293,7 +293,10 @@ def _open_nexus_file(
     definitions: Optional[Mapping] = None,
 ) -> ContextManager:
     if isinstance(file_path, getattr(NeXusGroup, '__supertype__', type(None))):
-        # Bug. Definitions ignored if the file_path is an already opened nexus file.
+        if definitions is not None:
+            raise ValueError(
+                "Cannot apply new definitions to open nexus file or nexus group."
+            )
         return nullcontext(file_path)
     if definitions is not None:
         return snx.File(file_path, definitions=definitions)

--- a/src/ess/reduce/nexus.py
+++ b/src/ess/reduce/nexus.py
@@ -12,7 +12,16 @@ the basic ones here.
 
 from contextlib import nullcontext
 from pathlib import Path
-from typing import BinaryIO, ContextManager, NewType, Optional, Type, Union, cast, Mapping
+from typing import (
+    BinaryIO,
+    ContextManager,
+    Mapping,
+    NewType,
+    Optional,
+    Type,
+    Union,
+    cast,
+)
 
 import scipp as sc
 import scippnexus as snx

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -206,13 +206,11 @@ def expected_sample() -> sc.DataGroup:
 
 
 @pytest.mark.parametrize('entry_name', [None, nexus.NeXusEntryName('entry-001')])
-@pytest.mark.parametrize('definitions', [None, {}])
-def test_load_detector(nexus_file, expected_bank12, entry_name, definitions):
+def test_load_detector(nexus_file, expected_bank12, entry_name):
     detector = nexus.load_detector(
         nexus_file,
         detector_name=nexus.NeXusDetectorName('bank12'),
         entry_name=entry_name,
-        #definitions=definitions,
     )
     sc.testing.assert_identical(detector['bank12_events'], expected_bank12)
     offset = detector_transformation_components()['offset']
@@ -220,6 +218,22 @@ def test_load_detector(nexus_file, expected_bank12, entry_name, definitions):
         detector['transform'],
         sc.spatial.translation(unit=offset.unit, value=offset.value),
     )
+
+
+def test_load_detector_open_file_with_new_definitions_raises(nexus_file):
+    if isinstance(nexus_file, snx.Group):
+        with pytest.raises(ValueError, match="new definitions"):
+            nexus.load_detector(
+                nexus_file,
+                detector_name=nexus.NeXusDetectorName('bank12'),
+                definitions={},
+            )
+    else:
+        nexus.load_detector(
+            nexus_file,
+            detector_name=nexus.NeXusDetectorName('bank12'),
+            definitions={},
+        )
 
 
 def test_load_detector_requires_entry_name_if_not_unique(nexus_file):
@@ -266,13 +280,11 @@ def test_load_monitor(nexus_file, expected_monitor, entry_name):
 
 @pytest.mark.parametrize('entry_name', [None, nexus.NeXusEntryName('entry-001')])
 @pytest.mark.parametrize('source_name', [None, nexus.NeXusSourceName('source')])
-@pytest.mark.parametrize('definitions', [None, {"something": "something else"}])
-def test_load_source(nexus_file, expected_source, entry_name, source_name, definitions):
+def test_load_source(nexus_file, expected_source, entry_name, source_name):
     source = nexus.load_source(
         nexus_file,
         entry_name=entry_name,
         source_name=source_name,
-        definitions=definitions,
     )
     # NeXus details that we don't need to test as long as the positions are ok:
     del source['depends_on']
@@ -281,9 +293,8 @@ def test_load_source(nexus_file, expected_source, entry_name, source_name, defin
 
 
 @pytest.mark.parametrize('entry_name', [None, nexus.NeXusEntryName('entry-001')])
-@pytest.mark.parametrize('definitions', [None, {"something": "something else"}])
-def test_load_sample(nexus_file, expected_sample, entry_name, definitions):
-    sample = nexus.load_sample(nexus_file, entry_name=entry_name, definitions=definitions)
+def test_load_sample(nexus_file, expected_sample, entry_name):
+    sample = nexus.load_sample(nexus_file, entry_name=entry_name)
     sc.testing.assert_identical(sample, nexus.RawSample(expected_sample))
 
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -206,11 +206,13 @@ def expected_sample() -> sc.DataGroup:
 
 
 @pytest.mark.parametrize('entry_name', [None, nexus.NeXusEntryName('entry-001')])
-def test_load_detector(nexus_file, expected_bank12, entry_name):
+@pytest.mark.parametrize('definitions', [None, {}])
+def test_load_detector(nexus_file, expected_bank12, entry_name, definitions):
     detector = nexus.load_detector(
         nexus_file,
         detector_name=nexus.NeXusDetectorName('bank12'),
         entry_name=entry_name,
+        #definitions=definitions,
     )
     sc.testing.assert_identical(detector['bank12_events'], expected_bank12)
     offset = detector_transformation_components()['offset']
@@ -264,11 +266,13 @@ def test_load_monitor(nexus_file, expected_monitor, entry_name):
 
 @pytest.mark.parametrize('entry_name', [None, nexus.NeXusEntryName('entry-001')])
 @pytest.mark.parametrize('source_name', [None, nexus.NeXusSourceName('source')])
-def test_load_source(nexus_file, expected_source, entry_name, source_name):
+@pytest.mark.parametrize('definitions', [None, {"something": "something else"}])
+def test_load_source(nexus_file, expected_source, entry_name, source_name, definitions):
     source = nexus.load_source(
         nexus_file,
         entry_name=entry_name,
         source_name=source_name,
+        definitions=definitions,
     )
     # NeXus details that we don't need to test as long as the positions are ok:
     del source['depends_on']
@@ -277,8 +281,9 @@ def test_load_source(nexus_file, expected_source, entry_name, source_name):
 
 
 @pytest.mark.parametrize('entry_name', [None, nexus.NeXusEntryName('entry-001')])
-def test_load_sample(nexus_file, expected_sample, entry_name):
-    sample = nexus.load_sample(nexus_file, entry_name=entry_name)
+@pytest.mark.parametrize('definitions', [None, {"something": "something else"}])
+def test_load_sample(nexus_file, expected_sample, entry_name, definitions):
+    sample = nexus.load_sample(nexus_file, entry_name=entry_name, definitions=definitions)
     sc.testing.assert_identical(sample, nexus.RawSample(expected_sample))
 
 

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -312,6 +312,32 @@ def test_load_source(nexus_file, expected_source, entry_name, source_name):
     sc.testing.assert_identical(source, nexus.RawSource(expected_source))
 
 
+@pytest.mark.parametrize(
+    ('loader', 'cls', 'name'),
+    [
+        (nexus.load_source, snx.NXsource, 'NXsource'),
+        (nexus.load_sample, snx.NXsample, 'NXsample'),
+    ],
+)
+def test_load_new_definitions_applied(nexus_file, loader, cls, name):
+    if not isinstance(nexus_file, snx.Group):
+        new_definition_used = False
+
+        def new(*args, **kwargs):
+            nonlocal new_definition_used
+            new_definition_used = True
+            return cls(*args, **kwargs)
+
+        loader(
+            nexus_file,
+            definitions={
+                **snx.base_definitions(),
+                name: new,
+            },
+        )
+        assert new_definition_used
+
+
 @pytest.mark.parametrize('entry_name', [None, nexus.NeXusEntryName('entry-001')])
 def test_load_sample(nexus_file, expected_sample, entry_name):
     sample = nexus.load_sample(nexus_file, entry_name=entry_name)

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -236,6 +236,26 @@ def test_load_detector_open_file_with_new_definitions_raises(nexus_file):
         )
 
 
+def test_load_detector_new_definitions_applied(nexus_file, expected_bank12):
+    if not isinstance(nexus_file, snx.Group):
+        new_definition_used = False
+
+        def detector(*args, **kwargs):
+            nonlocal new_definition_used
+            new_definition_used = True
+            return snx.base_definitions()['NXdetector'](*args, **kwargs)
+
+        nexus.load_detector(
+            nexus_file,
+            detector_name=nexus.NeXusDetectorName('bank12'),
+            definitions=dict(
+                snx.base_definitions(),
+                NXdetector=detector,
+            ),
+        )
+        assert new_definition_used
+
+
 def test_load_detector_requires_entry_name_if_not_unique(nexus_file):
     if not isinstance(nexus_file, Path):
         # For simplicity, only create a second entry in an actual file


### PR DESCRIPTION
Fixes #33 

There are a couple of issues remaining:

* If the `file_path` argument is an already opened nexus file,
  * can we add the definitions to that object (requires changes in scippnexus?)
  * or do we raise an error?
* What kind of definitions should we use in the tests?
    