### PR TITLE
Replace strict type var naming convention

### DIFF
--- a/docs/user-guide/reduction-workflow-guidelines.md
+++ b/docs/user-guide/reduction-workflow-guidelines.md
@@ -92,16 +92,13 @@ RunType = TypeVar('RunType', SampleRun, BackgroundRun)
 class Filename(sciline.Scope[RunType, str], str): ...
 ```
 
-### C.3: Carefully choose names of type vars
+### C.3: Use the suffix 'Type' for type vars
 
 **Reason**
-It is important that type vars can be distinguished from concrete domain types, and that it has a clear meaning.
+This makes it easier to distinguish type vars from concrete domain types.
 
 **Example**
-
-- `RunType` and `MonitorType` are examples where having the suffix `Type` can be useful, since `Run` could be confused with (or used as) a domain type giving the run number.
-  See 'RunType' and 'MonitorType' in the table of C.2.
-- `PolarizerSpin = TypeVar['PolarizerSpin', Up, Down]` probably does not require a `Type` suffix.
+See 'RunType' and 'MonitorType' in the table of C.2.
 
 ### C.4: Use flexible types
 

--- a/docs/user-guide/reduction-workflow-guidelines.md
+++ b/docs/user-guide/reduction-workflow-guidelines.md
@@ -92,13 +92,16 @@ RunType = TypeVar('RunType', SampleRun, BackgroundRun)
 class Filename(sciline.Scope[RunType, str], str): ...
 ```
 
-### C.3: Use the suffix 'Type' for type vars
+### C.3: Carefully choose names of type vars
 
 **Reason**
-This makes it easier to distinguish type vars from concrete domain types.
+It is important that type vars can be distinguished from concrete domain types, and that it has a clear meaning.
 
 **Example**
-See 'RunType' and 'MonitorType' in the table of C.2.
+
+- `RunType` and `MonitorType` are examples where having the suffix `Type` can be useful, since `Run` could be confused with (or used as) a domain type giving the run number.
+  See 'RunType' and 'MonitorType' in the table of C.2.
+- `PolarizerSpin = TypeVar['PolarizerSpin', Up, Down]` probably does not require a `Type` suffix.
 
 ### C.4: Use flexible types
 

--- a/docs/user-guide/reduction-workflow-guidelines.md
+++ b/docs/user-guide/reduction-workflow-guidelines.md
@@ -94,6 +94,9 @@ class Filename(sciline.Scope[RunType, str], str): ...
 
 ### C.3: (Removed rule on naming TypeVars)
 
+This guideline was too restrictive as not all TypeVars represent a "type", conceptually.
+Instead, authors should apply good judgment when naming TypeVars.
+
 ### C.4: Use flexible types
 
 **Reason**

--- a/docs/user-guide/reduction-workflow-guidelines.md
+++ b/docs/user-guide/reduction-workflow-guidelines.md
@@ -92,13 +92,7 @@ RunType = TypeVar('RunType', SampleRun, BackgroundRun)
 class Filename(sciline.Scope[RunType, str], str): ...
 ```
 
-### C.3: Use the suffix 'Type' for type vars
-
-**Reason**
-This makes it easier to distinguish type vars from concrete domain types.
-
-**Example**
-See 'RunType' and 'MonitorType' in the table of C.2.
+### C.3: (Removed rule on naming TypeVars)
 
 ### C.4: Use flexible types
 


### PR DESCRIPTION
Not entirely happy with this either. Should it simply be removed entirely, including the examples in the rule above? Or are we still happy with `RunType`?