### PR TITLE
Event broadcast with uncertainty upper-bounds

### DIFF
--- a/src/ess/reduce/uncertainty.py
+++ b/src/ess/reduce/uncertainty.py
@@ -96,12 +96,16 @@ def broadcast_with_upper_bound_variances(
                 if dim in irred.dims:
                     irred = irred.all(dim)
             mask = irred
-    size = (~mask).sum().value
-    for dim, dim_size in sizes.items():
-        if dim not in data.dims and dim not in mask.dims:
-            size *= dim_size
     data = data.copy()
-    data.variances *= size
+    if prototype.bins is None:
+        size = (~mask).sum().value
+        for dim, dim_size in sizes.items():
+            if dim not in data.dims and dim not in mask.dims:
+                size *= dim_size
+        data.variances *= size
+    else:
+        bin_sizes = prototype.bins.size().sum(set(prototype.dims) - set(data.dims))
+        data.variances *= bin_sizes.broadcast(sizes=data.sizes).values
     sizes = {**sizes, **data.sizes}
     data = data.broadcast(sizes=sizes).copy()
     if mask is not None:

--- a/src/ess/reduce/uncertainty.py
+++ b/src/ess/reduce/uncertainty.py
@@ -75,6 +75,19 @@ def broadcast_with_upper_bound_variances(
     """
     if _no_variance_broadcast(data, prototype):
         return data
+    for dim in prototype.dims:
+        coord1 = None if isinstance(data, sc.Variable) else data.coords.get(dim)
+        coord2 = (
+            None if isinstance(prototype, sc.Variable) else prototype.coords.get(dim)
+        )
+        if coord1 is None or coord2 is None:
+            if dim in data.dims:
+                if data.sizes[dim] != prototype.sizes[dim]:
+                    raise ValueError("Mismatching binning not supported in broadcast.")
+            continue
+        elif sc.identical(coord1, coord2):
+            continue
+        raise ValueError("Mismatching binning not supported in broadcast.")
     sizes = prototype.sizes
     mask = sc.scalar(False)
     if isinstance(prototype, sc.DataArray):

--- a/src/ess/reduce/uncertainty.py
+++ b/src/ess/reduce/uncertainty.py
@@ -107,7 +107,7 @@ def broadcast_with_upper_bound_variances(
     else:
         size = prototype.bins.size().sum(set(prototype.dims) - set(data.dims))
     scale = size.broadcast(sizes=sizes).to(dtype='float64')
-    if mask is not None:
+    if not sc.identical(mask, sc.scalar(False)):
         # The masked values are not counted in the variance, so we set them to infinity.
         scale.values[mask.broadcast(sizes=sizes).values] = np.inf
     data = data.broadcast(sizes=sizes).copy()

--- a/tests/uncertainty_test.py
+++ b/tests/uncertainty_test.py
@@ -226,7 +226,7 @@ def test_upper_bound_event_broadcast_event_count_excludes_masked():
     expected = prototype.copy().bins.constituents
     expected['data'].values[:10] = 1.0
     expected['data'].values[10:] = 2.0
-    # There are 5 bins along x, but 10 events, so variance scale factor is 10.
+    # There are 5 bins along x, but 10 events (4 masked), so variance scale factor is 6.
     expected['data'].variances = expected['data'].values * 6
     expected['data']['event', 0:1].variances = [np.inf]
     expected['data']['event', 7:10].variances = [np.inf, np.inf, np.inf]

--- a/tests/uncertainty_test.py
+++ b/tests/uncertainty_test.py
@@ -171,3 +171,39 @@ def test_upper_bound_broadcast_raises_if_input_is_binned():
     y = sc.linspace('y', 0.0, 1.0, 10)
     with pytest.raises(ValueError, match="Cannot broadcast binned data."):
         unc.broadcast_with_upper_bound_variances(x, prototype=y)
+
+
+def test_upper_bound_event_broadcast_raises_if_binning_mismatching():
+    prototype = sc.linspace('x', 0.0, 1.0, 10).bin(x=3).squeeze()
+    data = sc.DataArray(
+        sc.ones(dims=['x'], shape=[2], with_variances=True),
+        coords={'x': sc.linspace('x', 0.0, 1.0, 3)},
+    )
+    with pytest.raises(
+        ValueError, match="Mismatching binning not supported in broadcast."
+    ):
+        unc.broadcast_with_upper_bound_variances(data, prototype=prototype)
+
+
+def test_upper_bound_event_broadcast_counts_events():
+    content = sc.ones(dims=['event'], shape=[10])
+    # sizes = [0,1,2,4,3]
+    begin = sc.array(dims=['x'], values=[0, 0, 1, 3, 7], unit=None)
+    prototype = sc.bins(data=content, dim='event', begin=begin)
+    y = sc.array(dims=['y'], values=[1.0, 2.0], variances=[1.0, 2.0])
+    xy = unc.broadcast_with_upper_bound_variances(y, prototype=prototype)
+    # There are 5 bins along x, but 10 events, so variance scale factor is 10.
+    assert_identical(
+        xy,
+        sc.array(
+            dims=['x', 'y'],
+            values=[[1.0, 2.0], [1.0, 2.0], [1.0, 2.0], [1.0, 2.0], [1.0, 2.0]],
+            variances=[
+                [10.0, 20.0],
+                [10.0, 20.0],
+                [10.0, 20.0],
+                [10.0, 20.0],
+                [10.0, 20.0],
+            ],
+        ),
+    )

--- a/tests/uncertainty_test.py
+++ b/tests/uncertainty_test.py
@@ -205,7 +205,10 @@ def test_upper_bound_event_broadcast_counts_events():
     expected = sc.bins(**expected)
 
     assert_identical(upper_bound_broadcast, expected)
-    _ = prototype * upper_bound_broadcast  # Check that this does not raise.
+    # The point of broadcast_with_upper_bound_variances is that we can afterwards
+    # perform the following operation with getting a variance broadcast error.
+    # Did it work?
+    _ = prototype * upper_bound_broadcast
 
 
 def test_upper_bound_event_broadcast_event_count_excludes_masked():
@@ -235,7 +238,10 @@ def test_upper_bound_event_broadcast_event_count_excludes_masked():
     expected = sc.bins(**expected)
 
     assert_identical(upper_bound_broadcast, expected)
-    _ = prototype * upper_bound_broadcast  # Check that this does not raise.
+    # The point of broadcast_with_upper_bound_variances is that we can afterwards
+    # perform the following operation with getting a variance broadcast error.
+    # Did it work?
+    _ = prototype * upper_bound_broadcast
     assert sc.all(sc.isinf(sc.variances(upper_bound_broadcast['x', 1])))
     assert sc.all(sc.isinf(sc.variances(upper_bound_broadcast['x', 4])))
 
@@ -264,4 +270,7 @@ def test_upper_bound_event_broadcast_only_bin_broadcast():
     expected = sc.bins(**expected)
 
     assert_identical(upper_bound_broadcast, expected)
-    _ = prototype * upper_bound_broadcast  # Check that this does not raise.
+    # The point of broadcast_with_upper_bound_variances is that we can afterwards
+    # perform the following operation with getting a variance broadcast error.
+    # Did it work?
+    _ = prototype * upper_bound_broadcast

--- a/tests/uncertainty_test.py
+++ b/tests/uncertainty_test.py
@@ -163,3 +163,11 @@ def test_broadcast_into_nonorthogonal_2d_mask_reducible_mask_counts_masked():
     expected.variances *= 2
     expected['y', 1].variances = [np.inf, np.inf]
     assert_identical(xy, expected)
+
+
+def test_upper_bound_broadcast_raises_if_input_is_binned():
+    x = sc.linspace('x', 0.0, 1.0, 10).bin(x=1).squeeze()
+    x.value.variances = x.value.values
+    y = sc.linspace('y', 0.0, 1.0, 10)
+    with pytest.raises(ValueError, match="Cannot broadcast binned data."):
+        unc.broadcast_with_upper_bound_variances(x, prototype=y)


### PR DESCRIPTION
Fixes #20.

Prerequisite for scipp/essdiffraction#37, as well as rollout to ESSsans.

For review: Please verify is this is consistent with https://github.com/scipp/esssans/blob/d0386b93663efe64a97c93add25cb57839b635e3/src/ess/sans/uncertainty.py#L56-L78.
The implementation here can do more than that, but it must be consistent.