### PR TITLE
Add `nexus.load_event_data` and `nexus.group_event_data`

### DIFF
--- a/src/ess/reduce/nexus.py
+++ b/src/ess/reduce/nexus.py
@@ -436,3 +436,47 @@ def _select_unique_array(
             f"Got {mapping_name} items {set(arrays.keys())}"
         )
     return next(iter(arrays.values()))
+
+
+def load_event_data(
+    file_path: Union[FilePath, NeXusFile, NeXusGroup],
+    selection=(),
+    *,
+    entry_name: NeXusEntryName | None = None,
+    component_name: str,
+    definitions: Mapping | Literal[_no_new_definitions] | None = _no_new_definitions,
+) -> sc.DataArray:
+    with _open_nexus_file(file_path, definitions=definitions) as f:
+        entry = _unique_child_group(f, snx.NXentry, entry_name)
+        instrument = _unique_child_group(entry, snx.NXinstrument, None)
+        component = instrument[component_name]
+        event_data = _unique_child_group(component, snx.NXevent_data, None)
+        return event_data[selection]
+
+
+def group_event_data(
+    *, event_data: sc.DataArray, detector_number: sc.Variable
+) -> sc.DataArray:
+    """Group event data by detector number."""
+    event_id = detector_number.flatten(to='event_id').copy()
+    if 'event_time_zero' in event_data.coords:
+        event_data.bins.coords['event_time_zero'] = sc.bins_like(
+            event_data, fill_value=event_data.coords['event_time_zero']
+        )
+    constituents = event_data.bins.constituents
+    begin = constituents['begin']
+    end = constituents['end']
+    data = constituents['data']
+    # After loading raw NXevent_data it is guaranteed that the event table
+    # is contiguous and that there is no masking. We can therefore use the
+    # more efficient approach of binning from scratch instead of erasing the
+    # 'event_time_zero' binning defined by NXevent_data. This sanity check should
+    # therefore always pass unless some unusual modifications were performed.
+    if (
+        event_data.masks
+        or begin[0] != sc.index(0)
+        or end[-1] != sc.index(data.sizes[data.dim])
+        or (begin[1:] != end[:-1]).any()
+    ):
+        raise ValueError("Grouping only implemented for contiguous data with no masks.")
+    return data.group(event_id).fold(dim='event_id', sizes=detector_number.sizes)

--- a/src/ess/reduce/nexus.py
+++ b/src/ess/reduce/nexus.py
@@ -486,7 +486,7 @@ def group_event_data(
 ) -> sc.DataArray:
     """Group event data by detector number.
 
-    The detector_number variable also defined the output shape and dimension names.
+    The detector_number variable also defines the output shape and dimension names.
 
     Parameters
     ----------
@@ -502,6 +502,10 @@ def group_event_data(
     """
     event_id = detector_number.flatten(to='event_id').copy()
     if 'event_time_zero' in event_data.coords:
+        comps = event_data.bins.constituents
+        comps['data'] = comps['data'].copy(deep=False)
+        event_data = event_data.copy(deep=False)
+        event_data.data = sc._scipp.core._bins_no_validate(**comps)
         event_data.bins.coords['event_time_zero'] = sc.bins_like(
             event_data, fill_value=event_data.coords['event_time_zero']
         )

--- a/src/ess/reduce/nexus.py
+++ b/src/ess/reduce/nexus.py
@@ -501,18 +501,14 @@ def group_event_data(
         Data array with events grouped by detector number.
     """
     event_id = detector_number.flatten(to='event_id').copy()
-    if 'event_time_zero' in event_data.coords:
-        comps = event_data.bins.constituents
-        comps['data'] = comps['data'].copy(deep=False)
-        event_data = event_data.copy(deep=False)
-        event_data.data = sc._scipp.core._bins_no_validate(**comps)
-        event_data.bins.coords['event_time_zero'] = sc.bins_like(
-            event_data, fill_value=event_data.coords['event_time_zero']
-        )
     constituents = event_data.bins.constituents
     begin = constituents['begin']
     end = constituents['end']
-    data = constituents['data']
+    data = constituents['data'].copy(deep=False)
+    if 'event_time_zero' in event_data.coords:
+        data.coords['event_time_zero'] = sc.bins_like(
+            event_data, fill_value=event_data.coords['event_time_zero']
+        ).bins.constituents['data']
     # After loading raw NXevent_data it is guaranteed that the event table
     # is contiguous and that there is no masking. We can therefore use the
     # more efficient approach of binning from scratch instead of erasing the

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -236,6 +236,35 @@ def test_load_detector(nexus_file, expected_bank12, entry_name, selection):
     )
 
 
+@pytest.mark.parametrize(
+    'selection',
+    [
+        (),
+        {'event_time_zero': slice(2, None)},
+        {'event_time_zero': slice(None, 3)},
+        {'event_time_zero': slice(1, 3)},
+    ],
+)
+def test_load_and_group_event_data_consistent_with_load_via_detector(
+    nexus_file, selection
+):
+    detector = nexus.load_detector(
+        nexus_file,
+        selection=selection,
+        detector_name=nexus.NeXusDetectorName('bank12'),
+    )['bank12_events']
+    events = nexus.load_event_data(
+        nexus_file,
+        selection=selection,
+        component_name=nexus.NeXusDetectorName('bank12'),
+    )
+    grouped = nexus.group_event_data(
+        event_data=events,
+        detector_number=detector.coords['detector_number'],
+    )
+    scipp.testing.assert_identical(detector.data, grouped.data)
+
+
 def test_load_detector_open_file_with_new_definitions_raises(nexus_file):
     if isinstance(nexus_file, snx.Group):
         with pytest.raises(ValueError, match="new definitions"):

--- a/tests/nexus_test.py
+++ b/tests/nexus_test.py
@@ -265,6 +265,22 @@ def test_load_and_group_event_data_consistent_with_load_via_detector(
     scipp.testing.assert_identical(detector.data, grouped.data)
 
 
+def test_group_event_data_does_not_modify_input(nexus_file):
+    detector = nexus.load_detector(
+        nexus_file,
+        detector_name=nexus.NeXusDetectorName('bank12'),
+    )['bank12_events']
+    events = nexus.load_event_data(
+        nexus_file,
+        component_name=nexus.NeXusDetectorName('bank12'),
+    )
+    _ = nexus.group_event_data(
+        event_data=events,
+        detector_number=detector.coords['detector_number'],
+    )
+    assert 'event_time_zero' not in events.bins.coords
+
+
 def test_load_detector_open_file_with_new_definitions_raises(nexus_file):
     if isinstance(nexus_file, snx.Group):
         with pytest.raises(ValueError, match="new definitions"):


### PR DESCRIPTION
This addition is related to the new approach discussed in scipp/beamlime#215. By loading NXevent_data separately from the containing NXdetector or NXmonitor we increase flexibility, reduce overhead, and continue paving the path towards chunked processing of large files.