### PR TITLE
Workflow building helper.

### DIFF
--- a/docs/developer/gui.ipynb
+++ b/docs/developer/gui.ipynb
@@ -160,23 +160,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ess.reduce.ui import workflow_widget\n",
+    "\n",
+    "ess_widget = workflow_widget()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "nbsphinx": "hidden"
    },
    "outputs": [],
    "source": [
-    "from ess.reduce.ui import layout\n",
+    "from ess.reduce.ui import WorkflowWidget\n",
+    "\n",
     "# Select Workflow\n",
-    "_workflow_name, _workflow_obj = layout.children[0].children[0].options[0]\n",
-    "layout.children[0].children[0].value = _workflow_obj\n",
-    "del _workflow_name, _workflow_obj\n",
+    "ess_widget.children[0].children[0].value = RandomDistributionWorkflow\n",
     "# Set Output Parameter\n",
-    "layout.children[0].children[1].options[0]\n",
-    "layout.children[0].children[1].value = (layout.children[0].children[1].options[0],)\n",
-    "# Click ``Generate Parameters`` button\n",
-    "layout.children[0].children[3].children[0].click()\n",
-    "# Click ``Run Workflow`` button\n",
-    "layout.children[1].children[0].click()"
+    "body_widget: WorkflowWidget = ess_widget.children[1].children[0]\n",
+    "body_widget.output_selection_box.typical_outputs_widget.value = [Histogram]\n",
+    "body_widget.parameter_box.parameter_refresh_button.click()\n",
+    "body_widget.result_box.run_button.click()"
    ]
   },
   {
@@ -185,7 +193,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "layout"
+    "ess_widget"
    ]
   }
  ],

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -6,5 +6,6 @@
 ---
 maxdepth: 2
 ---
+widget
 reduction-workflow-guidelines
 ```

--- a/docs/user-guide/widget.md
+++ b/docs/user-guide/widget.md
@@ -1,0 +1,29 @@
+# Workflow Widget in Jupyter Notebook
+
+Users can run a workflow with our widget in a jupyter notebook.
+
+## Widget with All Workflows
+
+``workflow_widget`` will build a widget that you can select workflows among ``ess.reduce.workflow.workflow_registry``.
+
+**In order to select workflows from other ess packages, you will need to import the module that has the workflow constructor like the [Voila Example](#deploying-voila-application).**
+
+## Deploying Voila Application
+You need a jupyter notebook that contains these lines.
+
+
+```python
+from ess import loki  # loki module register workflows itself
+from ess.reduce.ui import workflow_widget
+
+ess_widget = workflow_widget()
+```
+And you can deploy the notebook as an application using voila command.
+```bash
+voila {PATH_TO_THE_NOTEBOOK}
+```
+
+## Widget from a Workflow in a Notebook
+```python
+from ess.reduce.
+```

--- a/src/ess/reduce/ui.py
+++ b/src/ess/reduce/ui.py
@@ -6,7 +6,7 @@ from typing import Any
 import ipywidgets as widgets
 import sciline as sl
 from IPython import display
-from ipywidgets import Layout, TwoByTwoLayout
+from ipywidgets import Layout
 
 from .parameter import Parameter
 from .widgets import SwitchWidget, create_parameter_widget, default_layout
@@ -91,7 +91,9 @@ class ParameterBox(widgets.VBox):
 
         super().__init__([self.parameter_refresh_button, self._input_box], **kwargs)
 
-    def collect_values(self) -> dict[Key, Any]:
+    @property
+    def value(self) -> dict[Key, Any]:
+        """Return the current parameter values with matching types as a dictionary."""
         return {
             node: widget.value
             for node, widget_box in self._input_widgets.items()
@@ -186,7 +188,7 @@ class WorkflowWidget(widgets.TwoByTwoLayout):
         def workflow_runner() -> dict[type, Any]:
             """Run the workflow with the current parameter values."""
             return assign_parameter_values(
-                workflow.copy(), self.parameter_box.collect_values()
+                workflow.copy(), self.parameter_box.value
             ).compute(self.output_selection_box.value)
 
         self.result_box = ResultBox(workflow_runner, result_registry)
@@ -215,7 +217,7 @@ class WorkflowWidget(widgets.TwoByTwoLayout):
 def workflow_widget_from_constructor(
     workflow_constructor: Callable[[], sl.Pipeline],
     result_registry: dict | None = None,
-) -> TwoByTwoLayout:
+) -> WorkflowWidget:
     """Create a widget for a workflow constructed from a workflow constructor."""
     workflow = workflow_constructor()
     return WorkflowWidget(workflow, result_registry)

--- a/src/ess/reduce/ui.py
+++ b/src/ess/reduce/ui.py
@@ -214,15 +214,6 @@ class WorkflowWidget(widgets.TwoByTwoLayout):
         )
 
 
-def workflow_widget_from_constructor(
-    workflow_constructor: Callable[[], sl.Pipeline],
-    result_registry: dict | None = None,
-) -> WorkflowWidget:
-    """Create a widget for a workflow constructed from a workflow constructor."""
-    workflow = workflow_constructor()
-    return WorkflowWidget(workflow, result_registry)
-
-
 def workflow_widget(result_registry: dict | None = None) -> widgets.Widget:
     """Create a widget for a workflow selected from a dropdown."""
     workflow_select = widgets.Dropdown(
@@ -234,9 +225,7 @@ def workflow_widget(result_registry: dict | None = None) -> widgets.Widget:
     )
 
     def refresh_workflow_box(change) -> None:
-        workflow_box.children = [
-            workflow_widget_from_constructor(change.new, result_registry)
-        ]
+        workflow_box.children = [WorkflowWidget(change.new(), result_registry)]
 
     workflow_select.observe(refresh_workflow_box, names='value')
 

--- a/src/ess/reduce/ui.py
+++ b/src/ess/reduce/ui.py
@@ -53,8 +53,10 @@ class OutputSelectionWidget(widgets.VBox):
         super().__init__([_typical_selection, _possible_selection], **kwargs)
 
     @property
-    def value(self):
-        return self.typical_outputs_widget.value + self.possible_outputs_widget.value
+    def value(self) -> set[Key]:
+        return set(
+            self.typical_outputs_widget.value + self.possible_outputs_widget.value
+        )
 
 
 class ParameterBox(widgets.VBox):

--- a/src/ess/reduce/ui.py
+++ b/src/ess/reduce/ui.py
@@ -155,9 +155,7 @@ def _workflow_runner_template(
     workflow = workflow_constructor()
     target_outputs = output_selection_box.value
     values = input_selection_box.collect_values()
-    return assign_parameter_values(workflow, values).compute(
-        target_outputs, scheduler=sl.scheduler.NaiveScheduler()
-    )
+    return assign_parameter_values(workflow, values).compute(target_outputs)
 
 
 def connect_refresh_button(

--- a/src/ess/reduce/widgets/_config.py
+++ b/src/ess/reduce/widgets/_config.py
@@ -2,5 +2,5 @@
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 from ipywidgets import Layout
 
-default_layout = Layout(width='80%')
+default_layout = Layout(width='100%')
 default_style = {'description_width': 'auto'}

--- a/src/ess/reduce/widgets/_switchable_widget.py
+++ b/src/ess/reduce/widgets/_switchable_widget.py
@@ -45,3 +45,7 @@ class SwitchWidget(HBox):
     @property
     def value(self) -> Any:
         return self.wrapped.value
+
+    @value.setter
+    def value(self, value: Any) -> None:
+        self.wrapped.value = value

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -69,6 +69,11 @@ def test_parameter_default_value_test() -> None:
     assert _get_param_widget(widget, float).value == 2.0
 
 
+def test_parameter_registry() -> None:
+    assert isinstance(create_parameter_widget(IntParam('_a', '_a', 1)), IntText)
+    assert isinstance(create_parameter_widget(FloatParam('_b', '_b', 2.0)), FloatText)
+
+
 def test_run_not_allowed_when_parameter_not_refreshed_after_output_selected() -> None:
     widget = _ready_widget(providers=[strict_provider], output_selections=[str])
     # Clear the value of the output selection box

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -63,6 +63,12 @@ def _get_param_widget(widget: WorkflowWidget, param_type: type) -> Any:
     return widget.parameter_box._input_widgets[param_type].children[0]
 
 
+def test_parameter_default_value_test() -> None:
+    widget = _ready_widget(providers=[strict_provider], output_selections=[str])
+    assert _get_param_widget(widget, int).value == 1
+    assert _get_param_widget(widget, float).value == 2.0
+
+
 def test_result_registry() -> None:
     registry = {}
     widget = _ready_widget(

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -1,7 +1,55 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
-from ess.reduce.parameter import Parameter
+from collections.abc import Callable
+from typing import Any, NewType
+
+import sciline as sl
+from ess.reduce.parameter import Parameter, parameter_registry
+from ess.reduce.ui import WorkflowWidget
 from ess.reduce.widgets import SwitchWidget, create_parameter_widget
+from ipywidgets import FloatText, IntText
+
+SwitchableInt = NewType('SwitchableInt', int)
+SwitchableFloat = NewType('SwitchableFloat', float)
+
+
+class IntParam(Parameter): ...
+
+
+class FloatParam(Parameter): ...
+
+
+SwitchableIntParam = IntParam('a', 'a', 1, switchable=True)
+SwitchableFloatParam = FloatParam('b', 'b', 2.0, switchable=True)
+
+parameter_registry[SwitchableInt] = SwitchableIntParam
+parameter_registry[SwitchableFloat] = SwitchableFloatParam
+
+
+@create_parameter_widget.register(IntParam)
+def _(param: IntParam) -> IntText:
+    return IntText(value=param.default, description=param.name)
+
+
+@create_parameter_widget.register(FloatParam)
+def _(param: FloatParam) -> FloatText:
+    return FloatText(value=param.default, description=param.name)
+
+
+def ready_widget(
+    *,
+    providers: list[Callable] | None = None,
+    params: dict[type, Any] | None = None,
+    output_selections: list[type],
+) -> WorkflowWidget:
+    widget = WorkflowWidget(sl.Pipeline(providers or [], params=params or {}))
+    widget.output_selection_box.typical_outputs_widget.value = output_selections
+    widget.parameter_box.parameter_refresh_button.click()
+    return widget
+
+
+def get_param_widget(widget: WorkflowWidget, param_type: type) -> Any:
+    return widget.parameter_box._input_widgets[param_type].children[0]
 
 
 def test_switchable_widget_dispatch() -> None:
@@ -11,22 +59,36 @@ def test_switchable_widget_dispatch() -> None:
     assert not isinstance(create_parameter_widget(non_switchable_param), SwitchWidget)
 
 
+def provider_with_switch(a: SwitchableInt, b: SwitchableFloat) -> str:
+    return f"{a} + {b}"
+
+
+def test_switchable_parameter_switch_widget() -> None:
+    widget = ready_widget(providers=[provider_with_switch], output_selections=[str])
+
+    int_widget = get_param_widget(widget, SwitchableInt)
+    float_widget = get_param_widget(widget, SwitchableFloat)
+
+    assert isinstance(int_widget, SwitchWidget)
+    assert isinstance(float_widget, SwitchWidget)
+
+    assert not float_widget.enabled
+    assert not int_widget.enabled
+
+
 def test_collect_values_from_disabled_switchable_widget() -> None:
-    from ess.reduce.ui import collect_values
-    from ipywidgets import Box, Text, VBox
+    widget = ready_widget(providers=[provider_with_switch], output_selections=[str])
 
-    enabled_switch_widget = SwitchWidget(Text('int'), name='int')
-    enabled_switch_widget.enabled = True
-    disabled_switch_widget = SwitchWidget(Text('float'), name='float')
-    disabled_switch_widget.enabled = False
-    non_switch_widget = Text('str')
-    test_box = VBox(
-        [
-            Box([enabled_switch_widget]),
-            Box([disabled_switch_widget]),
-            Box([non_switch_widget]),
-        ]
-    )
+    assert not get_param_widget(widget, SwitchableFloat).enabled
+    assert not get_param_widget(widget, SwitchableInt).enabled
+    assert widget.parameter_box.collect_values() == {}
 
-    values = collect_values(test_box, (int, float, str))
-    assert values == {int: 'int', str: 'str'}
+
+def test_collect_values_from_enabled_switchable_widget() -> None:
+    widget = ready_widget(providers=[provider_with_switch], output_selections=[str])
+
+    float_widget = get_param_widget(widget, SwitchableFloat)
+    float_widget.enabled = True
+    float_widget.value = 0.2
+
+    assert widget.parameter_box.collect_values() == {SwitchableFloat: 0.2}

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -135,7 +135,7 @@ def test_collect_values_from_disabled_switchable_widget() -> None:
 
     assert not _get_param_widget(widget, SwitchableFloat).enabled
     assert not _get_param_widget(widget, SwitchableInt).enabled
-    assert widget.parameter_box.collect_values() == {}
+    assert widget.parameter_box.value == {}
 
 
 def test_collect_values_from_enabled_switchable_widget() -> None:
@@ -145,7 +145,7 @@ def test_collect_values_from_enabled_switchable_widget() -> None:
     float_widget.enabled = True
     float_widget.value = 0.2
 
-    assert widget.parameter_box.collect_values() == {SwitchableFloat: 0.2}
+    assert widget.parameter_box.value == {SwitchableFloat: 0.2}
 
 
 def dummy_workflow_constructor() -> sl.Pipeline:

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -69,6 +69,22 @@ def test_parameter_default_value_test() -> None:
     assert _get_param_widget(widget, float).value == 2.0
 
 
+def test_run_not_allowed_when_parameter_not_refreshed_after_output_selected() -> None:
+    widget = _ready_widget(providers=[strict_provider], output_selections=[str])
+    # Clear the value of the output selection box
+    widget.output_selection_box.typical_outputs_widget.value = []
+    assert widget.result_box.run_button.disabled
+    # Click the refresh button
+    widget.parameter_box.parameter_refresh_button.click()
+    assert not widget.result_box.run_button.disabled
+    # Add a value to the parameter
+    widget.output_selection_box.typical_outputs_widget.value = [str]
+    assert widget.result_box.run_button.disabled
+    # Click the refresh button again
+    widget.parameter_box.parameter_refresh_button.click()
+    assert not widget.result_box.run_button.disabled
+
+
 def test_result_registry() -> None:
     registry = {}
     widget = _ready_widget(


### PR DESCRIPTION
Fixes #68

and partially related to #61 

I avoided spending too much time to make it prettier for now.

# Try Out
Now it's building new object everytime you call the helper function.

```python
from ess import loki
from ess.reduce.ui import workflow_widget

workflow_widget()
```

https://github.com/user-attachments/assets/fced63b7-14f9-456c-9d89-44570c578875


There is a smaller helper that create a widget for a certain pipeline constructor.

```python
from ess.reduce.ui import workflow_widget_from_constructor
from ess.loki.general import LokiAtLarmorTutorialWorkflow

workflow_widget_from_constructor(LokiAtLarmorTutorialWorkflow)
```
