### PR TITLE
Minor readability improvements in the widgets

### DIFF
--- a/src/ess/reduce/parameter.py
+++ b/src/ess/reduce/parameter.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import Generic, TypeVar
 
 import scipp as sc
+from sciline._utils import key_name
 from sciline.typing import Key
 
 T = TypeVar('T')
@@ -56,7 +57,7 @@ class Parameter(Generic[T]):
         # TODO __doc__ not correct when using Generic
         # use sciline type->string helper
         return cls(
-            name=str(t),
+            name=key_name(t),
             description=t.__doc__,
             default=default,
             optional=optional,

--- a/src/ess/reduce/ui.py
+++ b/src/ess/reduce/ui.py
@@ -34,7 +34,7 @@ class OutputSelectionWidget(widgets.VBox):
     def __init__(self, workflow: sl.Pipeline, **kwargs):
         self.typical_outputs_widget = widgets.SelectMultiple(
             options=get_typical_outputs(workflow),
-            layout=Layout(width='90%', height='auto'),
+            layout=Layout(width='90%', height='250px'),
         )
         self.possible_outputs_widget = widgets.SelectMultiple(
             options=get_possible_outputs(workflow),

--- a/src/ess/reduce/workflow.py
+++ b/src/ess/reduce/workflow.py
@@ -2,11 +2,12 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from collections.abc import Callable, MutableSet
+from collections.abc import Callable, MutableSet, Sequence
 from typing import Any, TypeVar
 
 import networkx as nx
 from sciline import Pipeline
+from sciline._utils import key_name
 from sciline.typing import Key
 
 from .parameter import Parameter, keep_default, parameter_mappers, parameter_registry
@@ -52,12 +53,17 @@ def get_typical_outputs(pipeline: Pipeline) -> tuple[Key, ...]:
     if (typical_outputs := getattr(pipeline, "typical_outputs", None)) is None:
         graph = pipeline.underlying_graph
         sink_nodes = [node for node, degree in graph.out_degree if degree == 0]
-        return tuple(sink_nodes)
-    return tuple(typical_outputs)
+        return _with_pretty_names(sink_nodes)
+    return _with_pretty_names(typical_outputs)
 
 
 def get_possible_outputs(pipeline: Pipeline) -> tuple[Key, ...]:
-    return tuple(pipeline.underlying_graph.nodes)
+    return sorted(_with_pretty_names(tuple(pipeline.underlying_graph.nodes)))
+
+
+def _with_pretty_names(outputs: Sequence[Key]) -> tuple[tuple[str, Key], ...]:
+    """Add a more readable string representation without full module path."""
+    return tuple((key_name(output), output) for output in outputs)
 
 
 def get_parameters(

--- a/src/ess/reduce/workflow.py
+++ b/src/ess/reduce/workflow.py
@@ -53,7 +53,7 @@ def get_typical_outputs(pipeline: Pipeline) -> tuple[Key, ...]:
     if (typical_outputs := getattr(pipeline, "typical_outputs", None)) is None:
         graph = pipeline.underlying_graph
         sink_nodes = [node for node, degree in graph.out_degree if degree == 0]
-        return _with_pretty_names(sink_nodes)
+        return sorted(_with_pretty_names(sink_nodes))
     return _with_pretty_names(typical_outputs)
 
 

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -278,7 +278,7 @@ def test_workflow_selection() -> None:
         first_widget = widget.children[1].children[0]
         assert isinstance(first_widget, WorkflowWidget)
         assert first_widget.output_selection_box.typical_outputs_widget.options == (
-            str,
+            ('str', str),
         )
         _refresh_widget_parameter(widget=first_widget, output_selections=[str])
         assert first_widget.parameter_box._input_widgets.keys() == {int, float}


### PR DESCRIPTION
Nothing of this is final, just making it marginally more usable for now:

- More vertical space to list typical outputs, removing need for scrolling
- Do not show full module path of keys in graph.

It looks like this now: 
<img width="1171" alt="image" src="https://github.com/user-attachments/assets/fd8e699b-c824-4b8c-bcf7-5161ed2a1884">
