### PR TITLE
Add streaming module

### DIFF
--- a/src/ess/reduce/streaming.py
+++ b/src/ess/reduce/streaming.py
@@ -128,8 +128,15 @@ class RollingAccumulator(Accumulator[T]):
             self._values.pop(0)
 
 
-class Streaming:
-    """Wrap a base workflow for streaming processing of chunks."""
+class StreamProcessor:
+    """
+    Wrap a base workflow for streaming processing of chunks.
+
+    Note that this class can not determine if the workflow is valid for streamed
+    processing based on the input keys. In particular, it is the responsibility of the
+    user to ensure that the workflow is "linear" with respect to the dynamic keys up to
+    the accumulation keys.
+    """
 
     def __init__(
         self,
@@ -140,6 +147,8 @@ class Streaming:
         accumulator: type[Accumulator] = EternalAccumulator,
     ) -> None:
         """
+        Create a stream processor.
+
         Parameters
         ----------
         base_workflow:

--- a/src/ess/reduce/streaming.py
+++ b/src/ess/reduce/streaming.py
@@ -183,6 +183,13 @@ class StreamProcessor:
             if isinstance(accumulators, dict)
             else {key: EternalAccumulator() for key in accumulators}
         )
+        # Depending on the target_keys, some accumulators can be unused and should not
+        # be computed when adding a chunk.
+        self._accumulators = {
+            key: value
+            for key, value in self._accumulators.items()
+            if key in self._process_chunk_workflow.underlying_graph
+        }
         self._target_keys = target_keys
 
     def add_chunk(

--- a/src/ess/reduce/streaming.py
+++ b/src/ess/reduce/streaming.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+"""This module provides tools for running workflows in a streaming fashion."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar
+
+import networkx as nx
+import sciline
+import scipp as sc
+
+T = TypeVar('T')
+
+
+def maybe_hist(value: T) -> T:
+    """
+    Convert value to a histogram if it is not already a histogram.
+
+    This is the default pre-processing used by accumulators.
+
+    Parameters
+    ----------
+    value:
+        Value to be converted to a histogram.
+
+    Returns
+    -------
+    :
+        Histogram.
+    """
+    return value if value.bins is None else value.hist()
+
+
+class Accumulator(ABC, Generic[T]):
+    """
+    Abstract base class for accumulators.
+
+    Accumulators are used to accumulate values over multiple chunks.
+    """
+
+    def __init__(self, preprocess: Callable[[T], T] | None = maybe_hist) -> None:
+        """
+        Parameters
+        ----------
+        preprocess:
+            Preprocessing function to be applied to pushed values prior to accumulation.
+        """
+        self._preprocess = preprocess
+
+    def push(self, value: T) -> None:
+        """
+        Push a value to the accumulator.
+
+        Parameters
+        ----------
+        value:
+            Value to be pushed to the accumulator.
+        """
+        if self._preprocess is not None:
+            value = self._preprocess(value)
+        self._do_push(value)
+
+    @abstractmethod
+    def _do_push(self, value: T) -> None: ...
+
+    @property
+    @abstractmethod
+    def value(self) -> T:
+        """
+        Get the accumulated value.
+
+        Returns
+        -------
+        :
+            Accumulated value.
+        """
+
+
+class EternalAccumulator(Accumulator[T]):
+    """
+    Simple accumulator that adds pushed values immediately.
+
+    Does not support event data.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._value: T | None = None
+
+    @property
+    def value(self) -> T:
+        return self._value.copy()
+
+    def _do_push(self, value: T) -> None:
+        if self._value is None:
+            self._value = value.copy()
+        else:
+            self._value += value
+
+
+class RollingAccumulator(Accumulator[T]):
+    """
+    Accumulator that adds pushed values to a rolling window.
+
+    Does not support event data.
+    """
+
+    def __init__(self, window: int = 10, **kwargs: Any) -> None:
+        """
+        Parameters
+        ----------
+        window:
+            Size of the rolling window.
+        """
+        super().__init__(**kwargs)
+        self._window = window
+        self._values: list[T] = []
+
+    @property
+    def value(self) -> T:
+        # Naive and potentially slow implementation if values and/or window are large!
+        return sc.reduce(self._values).sum()
+
+    def _do_push(self, value: T) -> None:
+        self._values.append(value)
+        if len(self._values) > self._window:
+            self._values.pop(0)
+
+
+class Streaming:
+    """Wrap a base workflow for streaming processing of chunks."""
+
+    def __init__(
+        self,
+        base_workflow: sciline.Pipeline,
+        dynamic_keys: tuple[sciline.typing.Key, ...],
+        accumulation_keys: tuple[sciline.typing.Key, ...],
+        target_keys: tuple[sciline.typing.Key, ...],
+        accumulator: type[Accumulator] = EternalAccumulator,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        base_workflow:
+            Workflow to be used for processing chunks.
+        dynamic_keys:
+            Keys that are expected to be updated with each chunk.
+        accumulation_keys:
+            Keys for which to accumulate values.
+        target_keys:
+            Keys to be computed and returned.
+        accumulator:
+            Accumulator class to use for accumulation.
+        """
+        workflow = sciline.Pipeline()
+        for key in target_keys:
+            workflow[key] = base_workflow[key]
+        for key in dynamic_keys:
+            workflow[key] = None  # hack to prune branches
+        # Find static nodes as far down the graph as possible
+        nodes = _find_descendants(workflow, dynamic_keys)
+        parents = _find_parents(workflow, nodes) - _find_input_nodes(workflow) - nodes
+        for key, value in base_workflow.compute(parents).items():
+            workflow[key] = value
+        self._process_chunk_workflow = workflow.copy()
+        self._finalize_workflow = workflow.copy()
+        self._accumulators = {key: accumulator() for key in accumulation_keys}
+        self._target_keys = target_keys
+
+    def add_chunk(
+        self, chunks: dict[sciline.typing.Key, Any]
+    ) -> dict[sciline.typing.Key, Any]:
+        for key, value in chunks.items():
+            self._process_chunk_workflow[key] = value
+        to_accumulate = self._process_chunk_workflow.compute(self._accumulators)
+        for key, processed in to_accumulate.items():
+            self._accumulators[key].push(processed)
+            self._finalize_workflow[key] = self._accumulators[key].value
+        return self._finalize_workflow.compute(self._target_keys)
+
+
+def _find_descendants(
+    workflow: sciline.Pipeline, keys: tuple[sciline.typing.Key, ...]
+) -> set[sciline.typing.Key]:
+    graph = workflow.underlying_graph
+    descendants = set()
+    for key in keys:
+        descendants |= nx.descendants(graph, key)
+    return descendants
+
+
+def _find_input_nodes(workflow: sciline.Pipeline) -> set[sciline.typing.Key]:
+    graph = workflow.underlying_graph
+    return {key for key in graph if graph.in_degree(key) == 0}
+
+
+def _find_parents(
+    workflow: sciline.Pipeline, keys: tuple[sciline.typing.Key, ...]
+) -> set[sciline.typing.Key]:
+    graph = workflow.underlying_graph
+    parents = set()
+    for key in keys:
+        parents |= set(graph.predecessors(key))
+    return parents

--- a/src/ess/reduce/streaming.py
+++ b/src/ess/reduce/streaming.py
@@ -197,6 +197,10 @@ class StreamProcessor:
     ) -> dict[sciline.typing.Key, Any]:
         for key, value in chunks.items():
             self._process_chunk_workflow[key] = value
+            # There can be dynamic keys that do not "terminate" in any accumulator. In
+            # that case, we need to make sure they can be and are used when computing
+            # the target keys.
+            self._finalize_workflow[key] = value
         to_accumulate = self._process_chunk_workflow.compute(self._accumulators)
         for key, processed in to_accumulate.items():
             self._accumulators[key].push(processed)

--- a/src/ess/reduce/streaming.py
+++ b/src/ess/reduce/streaming.py
@@ -158,13 +158,17 @@ class Streaming:
             workflow[key] = base_workflow[key]
         for key in dynamic_keys:
             workflow[key] = None  # hack to prune branches
-        # Find static nodes as far down the graph as possible
+
+        # Find and pre-compute static nodes as far down the graph as possible
+        # See also https://github.com/scipp/sciline/issues/148.
         nodes = _find_descendants(workflow, dynamic_keys)
         parents = _find_parents(workflow, nodes) - _find_input_nodes(workflow) - nodes
         for key, value in base_workflow.compute(parents).items():
             workflow[key] = value
+
         self._process_chunk_workflow = workflow.copy()
         self._finalize_workflow = workflow.copy()
+        # TODO: We may need to have a way to specify the accumulator for each key
         self._accumulators = {key: accumulator() for key in accumulation_keys}
         self._target_keys = target_keys
 

--- a/src/ess/reduce/streaming.py
+++ b/src/ess/reduce/streaming.py
@@ -162,7 +162,7 @@ class Streaming:
         # Find and pre-compute static nodes as far down the graph as possible
         # See also https://github.com/scipp/sciline/issues/148.
         nodes = _find_descendants(workflow, dynamic_keys)
-        parents = _find_parents(workflow, nodes) - _find_input_nodes(workflow) - nodes
+        parents = _find_parents(workflow, nodes) - nodes
         for key, value in base_workflow.compute(parents).items():
             workflow[key] = value
 
@@ -191,12 +191,7 @@ def _find_descendants(
     descendants = set()
     for key in keys:
         descendants |= nx.descendants(graph, key)
-    return descendants
-
-
-def _find_input_nodes(workflow: sciline.Pipeline) -> set[sciline.typing.Key]:
-    graph = workflow.underlying_graph
-    return {key for key in graph if graph.in_degree(key) == 0}
+    return descendants | set(keys)
 
 
 def _find_parents(

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -121,13 +121,13 @@ def make_target(accum_a: AccumA, accum_b: AccumB) -> Target:
     return Target(accum_a / accum_b)
 
 
-def test_streaming() -> None:
+def test_StreamProcessor() -> None:
     base_workflow = sciline.Pipeline(
         (make_static_a, make_accum_a, make_accum_b, make_target)
     )
     orig_workflow = base_workflow.copy()
 
-    streaming_wf = streaming.Streaming(
+    streaming_wf = streaming.StreamProcessor(
         base_workflow=base_workflow,
         dynamic_keys=(DynamicA, DynamicB),
         accumulation_keys=(AccumA, AccumB),

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -176,3 +176,28 @@ def test_StreamProcessor_uses_custom_accumulator() -> None:
     assert sc.identical(result[Target], sc.scalar(2 * 3.0 / 42.0))
     result = streaming_wf.add_chunk({DynamicA: sc.scalar(3), DynamicB: sc.scalar(6)})
     assert sc.identical(result[Target], sc.scalar(2 * 6.0 / 42.0))
+
+
+def test_StreamProcessor_does_not_compute_unused_static_nodes() -> None:
+    def a_independent_target(accum_b: AccumB) -> Target:
+        return Target(1.5 * accum_b)
+
+    def derived_static_a(x: float) -> StaticA:
+        derived_static_a.call_count += 1
+        return StaticA(2.0 * x)
+
+    derived_static_a.call_count = 0
+
+    base_workflow = sciline.Pipeline(
+        (derived_static_a, make_accum_a, make_accum_b, a_independent_target)
+    )
+
+    streaming_wf = streaming.StreamProcessor(
+        base_workflow=base_workflow,
+        dynamic_keys=(DynamicA, DynamicB),
+        target_keys=(Target,),
+        accumulators=(AccumA, AccumB),
+    )
+    result = streaming_wf.add_chunk({DynamicA: sc.scalar(1), DynamicB: sc.scalar(4)})
+    assert sc.identical(result[Target], sc.scalar(1.5 * 4.0))
+    assert derived_static_a.call_count == 0

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -125,6 +125,7 @@ def test_streaming() -> None:
     base_workflow = sciline.Pipeline(
         (make_static_a, make_accum_a, make_accum_b, make_target)
     )
+    orig_workflow = base_workflow.copy()
 
     streaming_wf = streaming.Streaming(
         base_workflow=base_workflow,
@@ -140,8 +141,8 @@ def test_streaming() -> None:
     assert sc.identical(result[Target], sc.scalar(2 * 6.0 / 15.0))
     assert make_static_a.call_count == 1
 
-    wf = base_workflow.copy()
-    wf[DynamicA] = sc.scalar(1 + 2 + 3)
-    wf[DynamicB] = sc.scalar(4 + 5 + 6)
-    expected = wf.compute(Target)
-    assert sc.identical(expected, sc.scalar(2 * 6.0 / 15.0))
+    # Consistency check: Run the original workflow with the same inputs, all at once
+    orig_workflow[DynamicA] = sc.scalar(1 + 2 + 3)
+    orig_workflow[DynamicB] = sc.scalar(4 + 5 + 6)
+    expected = orig_workflow.compute(Target)
+    assert sc.identical(expected, result[Target])

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+
+import scipp as sc
+
+from ess.reduce import streaming
+
+
+def test_eternal_accumulator_sums_everything():
+    accum = streaming.EternalAccumulator()
+    var = sc.linspace(dim='x', start=0, stop=1, num=10)
+    for i in range(10):
+        accum.push(var[i].copy())
+    assert sc.identical(accum.value, sc.sum(var))
+
+
+def test_eternal_accumulator_sums_everything_with_preprocess():
+    accum = streaming.EternalAccumulator(preprocess=lambda x: x**0.5)
+    var = sc.linspace(dim='x', start=0, stop=1, num=10)
+    for i in range(10):
+        accum.push(var[i].copy())
+    assert sc.identical(accum.value, sc.sum(var**0.5))
+
+
+def test_eternal_accumulator_works_if_output_value_is_modified():
+    accum = streaming.EternalAccumulator()
+    var = sc.linspace(dim='x', start=0, stop=1, num=10)
+    for i in range(10):
+        accum.push(var[i].copy())
+    value = accum.value
+    value += 1.0
+    assert sc.identical(accum.value, sc.sum(var))
+
+
+def test_eternal_accumulator_does_not_modify_pushed_values():
+    accum = streaming.EternalAccumulator()
+    var = sc.linspace(dim='x', start=0, stop=1, num=10)
+    original = var.copy()
+    for i in range(10):
+        accum.push(var[i])
+    assert sc.identical(var, original)
+
+
+def test_rolling_accumulator_sums_over_window():
+    accum = streaming.RollingAccumulator(window=3)
+    var = sc.linspace(dim='x', start=0, stop=1, num=10)
+    accum.push(var[0].copy())
+    assert sc.identical(accum.value, var[0])
+    accum.push(var[1].copy())
+    assert sc.identical(accum.value, var[0:2].sum())
+    accum.push(var[2].copy())
+    assert sc.identical(accum.value, var[0:3].sum())
+    accum.push(var[3].copy())
+    assert sc.identical(accum.value, var[1:4].sum())
+    accum.push(var[4].copy())
+    assert sc.identical(accum.value, var[2:5].sum())
+
+
+def test_rolling_accumulator_sums_over_window_with_preprocess():
+    accum = streaming.RollingAccumulator(window=3, preprocess=lambda x: x**0.5)
+    var = sc.linspace(dim='x', start=0, stop=1, num=10)
+    accum.push(var[0].copy())
+    assert sc.identical(accum.value, var[0] ** 0.5)
+    accum.push(var[1].copy())
+    assert sc.identical(accum.value, (var[0:2] ** 0.5).sum())
+    accum.push(var[2].copy())
+    assert sc.identical(accum.value, (var[0:3] ** 0.5).sum())
+    accum.push(var[3].copy())
+    assert sc.identical(accum.value, (var[1:4] ** 0.5).sum())
+    accum.push(var[4].copy())
+    assert sc.identical(accum.value, (var[2:5] ** 0.5).sum())
+
+
+def test_rolling_accumulator_works_if_output_value_is_modified():
+    accum = streaming.RollingAccumulator(window=3)
+    var = sc.linspace(dim='x', start=0, stop=1, num=10)
+    for i in range(10):
+        accum.push(var[i].copy())
+    value = accum.value
+    value += 1.0
+    assert sc.identical(accum.value, var[7:10].sum())
+
+
+def test_rolling_accumulator_does_not_modify_pushed_values():
+    accum = streaming.RollingAccumulator(window=3)
+    var = sc.linspace(dim='x', start=0, stop=1, num=10)
+    original = var.copy()
+    for i in range(10):
+        accum.push(var[i])
+    assert sc.identical(var, original)


### PR DESCRIPTION
This adds `ess.reduce.streaming`, mainly providing `StreamProcessor`. This is intended for use with Beamlime, processing chunks of detector and monitor event-data form a stream.

For context, this is how this could be used with a workflow from ESSsans:

```python
%matplotlib widget
dummy = sc.DataArray(
    sc.zeros(dims=('Q',), shape=(100,), with_variances=True),
    coords={'Q': sc.linspace('Q', 0.0, 1.0, 101, unit='1/angstrom')},
)
fig = dummy.plot(norm='log', scale={'Q': 'log'}, vmin=0.1, vmax=5)
artist = next(iter(fig.artists))
display(fig)
```

```python
from ess.reduce import streaming

streaming_wf = streaming.StreamProcessor(
    base_workflow=workflow,
    dynamic_keys=(
        NeXusMonitorEventData[SampleRun, Incident],
        NeXusDetectorEventData[SampleRun],
    ),
    target_keys=(IofQ[SampleRun],),
    accumulators={
        ReducedQ[SampleRun, Numerator]:streaming.RollingAccumulator(window=5),
        ReducedQ[SampleRun, Denominator]:streaming.RollingAccumulator(window=5),
    },
)

# This Loki data has different det and mon time scales
det_stride = 60
mon_stride = 1
for i in range(100):
    # assume we have loaded events manually somehow, this is not using an actual stream of events
    det_chunk = det_events[det_stride * i : det_stride * (i + 1)].copy()
    mon_chunk = mon_events[mon_stride * i : mon_stride * (i + 1)].copy()
    # simulate temporary loss of detector data
    if 20 < i < 30:
        det_chunk *= 0.0
    results = streaming_wf.add_chunk(
        {
            NeXusDetectorEventData[SampleRun]: det_chunk,
            NeXusMonitorEventData[SampleRun, Incident]: mon_chunk,
        }
    )
    fig.update({artist: results[IofQ[SampleRun]]})
    fig.fig.canvas.draw()
    fig.fig.canvas.flush_events()
```