### PR TITLE
Support preopening NeXus files

### DIFF
--- a/src/ess/reduce/nexus/_nexus_loader.py
+++ b/src/ess/reduce/nexus/_nexus_loader.py
@@ -67,7 +67,10 @@ def _open_nexus_file(
     definitions: Mapping | None | NoNewDefinitionsType = NoNewDefinitions,
 ) -> AbstractContextManager:
     if isinstance(file_path, getattr(NeXusGroup, '__supertype__', type(None))):
-        if definitions is not NoNewDefinitions:
+        if (
+            definitions is not NoNewDefinitions
+            and definitions != file_path._definitions
+        ):
             raise ValueError(
                 "Cannot apply new definitions to open nexus file or nexus group."
             )

--- a/src/ess/reduce/nexus/generic_workflow.py
+++ b/src/ess/reduce/nexus/generic_workflow.py
@@ -238,34 +238,27 @@ _detector_providers = (
     assemble_detector_data,
 )
 
-_default_params = {
-    PulseSelection: PulseSelection(()),
-    PreopenNeXusFile: PreopenNeXusFile(False),
-}
-
 
 def LoadMonitorWorkflow() -> sciline.Pipeline:
     """Generic workflow for loading monitor data from a NeXus file."""
-    wf = sciline.Pipeline(
-        (*_common_providers, *_monitor_providers), params=_default_params
-    )
+    wf = sciline.Pipeline((*_common_providers, *_monitor_providers))
+    wf[PreopenNeXusFile] = PreopenNeXusFile(False)
     return wf
 
 
 def LoadDetectorWorkflow() -> sciline.Pipeline:
     """Generic workflow for loading detector data from a NeXus file."""
-    wf = sciline.Pipeline(
-        (*_common_providers, *_detector_providers), params=_default_params
-    )
+    wf = sciline.Pipeline((*_common_providers, *_detector_providers))
     wf[DetectorBankSizes] = DetectorBankSizes({})
+    wf[PreopenNeXusFile] = PreopenNeXusFile(False)
     return wf
 
 
 def GenericNeXusWorkflow() -> sciline.Pipeline:
     """Generic workflow for loading detector and monitor data from a NeXus file."""
     wf = sciline.Pipeline(
-        (*_common_providers, *_monitor_providers, *_detector_providers),
-        params=_default_params,
+        (*_common_providers, *_monitor_providers, *_detector_providers)
     )
     wf[DetectorBankSizes] = DetectorBankSizes({})
+    wf[PreopenNeXusFile] = PreopenNeXusFile(False)
     return wf

--- a/src/ess/reduce/nexus/types.py
+++ b/src/ess/reduce/nexus/types.py
@@ -78,6 +78,9 @@ Component = TypeVar('Component', bound=snx.NXobject)
 
 AnyRunFilename = FilePath | NeXusFile | NeXusGroup
 
+PreopenNeXusFile = NewType('PreopenNeXusFile', bool)
+"""Whether to preopen NeXus files before passing them to the rest of the workflow."""
+
 
 @dataclass
 class NeXusLocationSpec(Generic[Component]):

--- a/src/ess/reduce/nexus/workflow.py
+++ b/src/ess/reduce/nexus/workflow.py
@@ -210,8 +210,6 @@ def load_nexus_detector(
     location:
         Location spec for the detector group.
     """
-    definitions = snx.base_definitions()
-    definitions["NXdetector"] = _StrippedDetector
     # The selection is only used for selecting a range of event data.
     location = replace(location, selection=())
 
@@ -251,8 +249,6 @@ def load_nexus_monitor(
     location:
         Location spec for the monitor group.
     """
-    definitions = snx.base_definitions()
-    definitions["NXmonitor"] = _StrippedMonitor
     return AnyRunAnyNeXusMonitor(
         nexus.load_component(location, nx_class=snx.NXmonitor, definitions=definitions)
     )
@@ -506,6 +502,11 @@ def _add_variances(da: sc.DataArray) -> sc.DataArray:
         if content.variances is None:
             content.variances = content.values
     return out
+
+
+definitions = snx.base_definitions()
+definitions["NXdetector"] = _StrippedDetector
+definitions["NXmonitor"] = _StrippedMonitor
 
 
 def LoadMonitorWorkflow() -> sciline.Pipeline:

--- a/tests/nexus/nexus_loader_test.py
+++ b/tests/nexus/nexus_loader_test.py
@@ -297,6 +297,10 @@ def test_load_detector_open_file_with_new_definitions_raises(nexus_file):
     if isinstance(nexus_file, snx.Group):
         with pytest.raises(ValueError, match="new definitions"):
             nexus.load_component(loc, nx_class=snx.NXdetector, definitions={})
+        # Passing same definitions should work
+        nexus.load_component(
+            loc, nx_class=snx.NXdetector, definitions=nexus_file._definitions.copy()
+        )
     else:
         nexus.load_component(loc, nx_class=snx.NXdetector, definitions={})
 


### PR DESCRIPTION
This is not strictly required by anything right now, but I needed it for some testing, so a cleaned it up for the future.

Changes:
- Be more relaxed about passing definitions for open groups.
- Add flag to optionally open NeXus files. This may become more relevant in the future when loading even more different parts and/or chunks from files.