### PR TITLE
Load histogram monitors

### DIFF
--- a/src/ess/reduce/nexus/__init__.py
+++ b/src/ess/reduce/nexus/__init__.py
@@ -13,6 +13,7 @@ The submodule :mod:`types` defines all domain types.
 from . import types
 from ._nexus_loader import (
     load_event_data,
+    load_hist_data,
     group_event_data,
     load_component,
     compute_component_position,
@@ -23,6 +24,7 @@ __all__ = [
     'types',
     'group_event_data',
     'load_event_data',
+    'load_hist_data',
     'load_component',
     'compute_component_position',
     'extract_events_or_histogram',

--- a/src/ess/reduce/nexus/generic_types.py
+++ b/src/ess/reduce/nexus/generic_types.py
@@ -115,6 +115,12 @@ class NeXusMonitorEventData(
     """Data array loaded from a NeXus NXevent_data group within an NXmonitor."""
 
 
+class NeXusMonitorHistData(
+    sciline.ScopeTwoParams[RunType, MonitorType, sc.DataArray], sc.DataArray
+):
+    """Data array loaded from a NeXus NXdata group within an NXmonitor."""
+
+
 class SourcePosition(sciline.Scope[RunType, sc.Variable], sc.Variable):
     """Position of the neutron source."""
 
@@ -198,3 +204,10 @@ class NeXusMonitorEventLocationSpec(
     NeXusLocationSpec[snx.NXevent_data], Generic[RunType, MonitorType]
 ):
     """NeXus filename and parameters to identify (parts of) monitor events to load."""
+
+
+@dataclass
+class NeXusMonitorHistLocationSpec(
+    NeXusLocationSpec[snx.NXdata], Generic[RunType, MonitorType]
+):
+    """NeXus filename and parameters to identify a monitor histogram to load."""

--- a/src/ess/reduce/nexus/types.py
+++ b/src/ess/reduce/nexus/types.py
@@ -47,6 +47,8 @@ AnyRunNeXusDetectorEventData = NewType('AnyRunNeXusDetectorEventData', sc.DataAr
 """Data array loaded from a NeXus NXevent_data group within an NXdetector."""
 AnyRunAnyNeXusMonitorEventData = NewType('AnyRunAnyNeXusMonitorEventData', sc.DataArray)
 """Data array loaded from a NeXus NXevent_data group within an NXmonitor."""
+AnyRunAnyNeXusMonitorHistData = NewType('AnyRunAnyNeXusMonitorHistData', sc.DataArray)
+"""Data array loaded from a NeXus NXdata group within an NXmonitor."""
 
 AnyRunSourcePosition = NewType('AnyRunSourcePosition', sc.Variable)
 """Position of the neutron source."""
@@ -94,3 +96,8 @@ class NeXusLocationSpec(Generic[Component]):
 @dataclass
 class NeXusEventDataLocationSpec(NeXusLocationSpec[Component]):
     """NeXus filename and parameters to identify (parts of) events to load."""
+
+
+@dataclass
+class NeXusHistDataLocationSpec(NeXusLocationSpec[Component]):
+    """NeXus filename and parameters to identify (parts of) a histogram to load."""

--- a/src/ess/reduce/nexus/workflow.py
+++ b/src/ess/reduce/nexus/workflow.py
@@ -19,6 +19,7 @@ from .types import (
     AnyRunAnyMonitorPositionOffset,
     AnyRunAnyNeXusMonitor,
     AnyRunAnyNeXusMonitorEventData,
+    AnyRunAnyNeXusMonitorHistData,
     AnyRunCalibratedDetector,
     AnyRunDetectorData,
     AnyRunDetectorPositionOffset,
@@ -34,6 +35,7 @@ from .types import (
     GravityVector,
     NeXusDetectorName,
     NeXusEventDataLocationSpec,
+    NeXusHistDataLocationSpec,
     NeXusLocationSpec,
 )
 
@@ -292,6 +294,27 @@ def load_nexus_monitor_event_data(
     """
     return AnyRunAnyNeXusMonitorEventData(
         nexus.load_event_data(
+            file_path=location.filename,
+            entry_name=location.entry_name,
+            selection=location.selection,
+            component_name=location.component_name,
+        )
+    )
+
+
+def load_nexus_monitor_histogram_data(
+    location: NeXusHistDataLocationSpec[snx.NXmonitor],
+) -> AnyRunAnyNeXusMonitorHistData:
+    """
+    Load histogram data from a NeXus monitor group.
+
+    Parameters
+    ----------
+    location:
+        Location spec for the monitor group.
+    """
+    return AnyRunAnyNeXusMonitorHistData(
+        nexus.load_hist_data(
             file_path=location.filename,
             entry_name=location.entry_name,
             selection=location.selection,

--- a/tests/nexus/nexus_loader_test.py
+++ b/tests/nexus/nexus_loader_test.py
@@ -500,3 +500,8 @@ def test_extract_detector_data_favors_event_data_over_histogram_data():
     )
     data = nexus.extract_events_or_histogram(nexus.types.AnyRunNeXusDetector(detector))
     sc.testing.assert_identical(data, nexus.types.RawDetectorData(detector['lob']))
+
+
+def test_load_histogram_data_loads_expected_data(nexus_file):
+    loaded = nexus.load_hist_data(nexus_file, component_name='monitor')
+    sc.testing.assert_identical(loaded, _monitor_histogram())

--- a/tests/nexus/workflow_test.py
+++ b/tests/nexus/workflow_test.py
@@ -300,7 +300,7 @@ def monitor_event_data() -> workflow.AnyRunAnyNeXusMonitorEventData:
 def test_assemble_monitor_data_adds_events_as_values_and_coords(
     calibrated_monitor, monitor_event_data
 ) -> None:
-    monitor_data = workflow.assemble_monitor_data(
+    monitor_data = workflow.assemble_monitor_event_data(
         calibrated_monitor, monitor_event_data
     )
     assert_identical(
@@ -311,7 +311,7 @@ def test_assemble_monitor_data_adds_events_as_values_and_coords(
 def test_assemble_monitor_data_adds_variances_to_weights(
     calibrated_monitor, monitor_event_data
 ) -> None:
-    monitor_data = workflow.assemble_monitor_data(
+    monitor_data = workflow.assemble_monitor_event_data(
         calibrated_monitor, monitor_event_data
     )
     assert_identical(
@@ -322,7 +322,7 @@ def test_assemble_monitor_data_adds_variances_to_weights(
 
 def test_assemble_monitor_preserves_coords(calibrated_monitor, monitor_event_data):
     calibrated_monitor.coords['abc'] = sc.scalar(1.2)
-    monitor_data = workflow.assemble_monitor_data(
+    monitor_data = workflow.assemble_monitor_event_data(
         calibrated_monitor, monitor_event_data
     )
     assert 'abc' in monitor_data.coords
@@ -330,7 +330,7 @@ def test_assemble_monitor_preserves_coords(calibrated_monitor, monitor_event_dat
 
 def test_assemble_monitor_preserves_masks(calibrated_monitor, monitor_event_data):
     calibrated_monitor.masks['mymask'] = sc.scalar(False)
-    monitor_data = workflow.assemble_monitor_data(
+    monitor_data = workflow.assemble_monitor_event_data(
         calibrated_monitor, monitor_event_data
     )
     assert 'mymask' in monitor_data.masks


### PR DESCRIPTION
This adds the option to load histogram data for monitors instead of event data. While we may not need this in production, simulated data may use histogram monitors instead of event monitors.

In particular, ESSspectroscopy needs this feature. I tested it locally with that pacakge. Note #103 about testing.