### PR TITLE
Binedges widget

### DIFF
--- a/src/ess/reduce/parameter.py
+++ b/src/ess/reduce/parameter.py
@@ -90,13 +90,29 @@ class MultiFilenameParameter(Parameter[tuple[str, ...]]):
 class BinEdgesParameter(Parameter[sc.Variable]):
     """Widget for entering bin edges."""
 
-    # dim and unit displayed in widget to provide context of numbers
     dim: str
-    unit: str
+    start: float | None = None
+    stop: float | None = None
+    nbins: int = 1
+    unit: str | None = "undefined"  # If "undefined", the unit is deduced from the dim
+    log: bool = False
 
-    def __init__(self, t: type[T], dim: str, unit: str):
+    def __init__(
+        self,
+        t: type[T],
+        dim: str,
+        start: float | None = None,
+        stop: float | None = None,
+        nbins: int = 1,
+        unit: str | None = "undefined",
+        log: bool = False,
+    ):
         self.dim = dim
+        self.start = start
+        self.stop = stop
+        self.nbins = nbins
         self.unit = unit
+        self.log = log
         super().__init__(name=str(t), description=t.__doc__, default=None)
 
 

--- a/src/ess/reduce/parameter.py
+++ b/src/ess/reduce/parameter.py
@@ -113,7 +113,7 @@ class BinEdgesParameter(Parameter[sc.Variable]):
         self.nbins = nbins
         self.unit = unit
         self.log = log
-        super().__init__(name=str(t), description=t.__doc__, default=None)
+        super().__init__(name=key_name(t), description=t.__doc__, default=None)
 
 
 @dataclass

--- a/src/ess/reduce/widgets/__init__.py
+++ b/src/ess/reduce/widgets/__init__.py
@@ -19,6 +19,7 @@ from ..parameter import (
 )
 from ._config import default_layout, default_style
 
+from ._binedges_widget import BinEdgesWidget
 from ._linspace_widget import LinspaceWidget
 from ._vector_widget import VectorWidget
 from ._bounds_widget import BoundsWidget
@@ -156,9 +157,14 @@ def param_with_bounds_widget(param: ParamWithBounds):
 
 @create_parameter_widget.register(BinEdgesParameter)
 def bin_edges_parameter_widget(param: BinEdgesParameter):
-    dim = param.dim
-    unit = param.unit
-    return LinspaceWidget(dim, unit)
+    return BinEdgesWidget(
+        dim=param.dim,
+        start=param.start,
+        stop=param.stop,
+        nbins=param.nbins,
+        unit=param.unit,
+        log=param.log,
+    )
 
 
 @create_parameter_widget.register(VectorParameter)
@@ -167,6 +173,7 @@ def vector_parameter_widget(param: VectorParameter):
 
 
 __all__ = [
+    'BinEdgesWidget',
     'BoundsWidget',
     'EssWidget',
     'LinspaceWidget',

--- a/src/ess/reduce/widgets/__init__.py
+++ b/src/ess/reduce/widgets/__init__.py
@@ -158,6 +158,7 @@ def param_with_bounds_widget(param: ParamWithBounds):
 @create_parameter_widget.register(BinEdgesParameter)
 def bin_edges_parameter_widget(param: BinEdgesParameter):
     return BinEdgesWidget(
+        name=param.name,
         dim=param.dim,
         start=param.start,
         stop=param.stop,

--- a/src/ess/reduce/widgets/_binedges_widget.py
+++ b/src/ess/reduce/widgets/_binedges_widget.py
@@ -48,8 +48,8 @@ class BinEdgesWidget(ipw.HBox, ipw.ValueWidget):
             "start": ipw.FloatText(description='start:', value=start, **style),
             "stop": ipw.FloatText(description='stop:', value=stop, **style),
             "nbins": ipw.BoundedIntText(
-                description='nbins:', value=nbins, min=1, **style
-            ),
+                description='nbins:', value=nbins, min=1, max=int(1e9), **style
+            ),  # Note that a max value is required as it defaults to 100 without it.
             "spacing": ipw.Dropdown(
                 options=['linear', 'log'],
                 value='log' if log else 'linear',

--- a/src/ess/reduce/widgets/_binedges_widget.py
+++ b/src/ess/reduce/widgets/_binedges_widget.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 import ipywidgets as ipw
-import numpy as np
 import scipp as sc
 
 UNITS_LIBRARY = {

--- a/src/ess/reduce/widgets/_binedges_widget.py
+++ b/src/ess/reduce/widgets/_binedges_widget.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import ipywidgets as ipw
+import numpy as np
+import scipp as sc
+
+UNITS_LIBRARY = {
+    "wavelength": {"options": ("angstrom", "nm")},
+    "Q": {"options": ("1/angstrom", "1/nm")},
+    "Qx": {"options": ("1/angstrom", "1/nm")},
+    "Qy": {"options": ("1/angstrom", "1/nm")},
+    "tof": {"options": ("s", "ms", "us", "ns"), "selected": "us"},
+    "dspacing": {"options": ("angstrom", "nm")},
+    "energy_transfer": {"options": ("meV",)},
+    "theta": {"options": ("rad", "deg")},
+    "two_theta": {"options": ("rad", "deg")},
+    "phi": {"options": ("rad", "deg")},
+    "time": {"options": ("s", "ms", "us", "ns")},
+    "temperature": {"options": ("K", "C", "F")},
+}
+
+
+class BinEdgesWidget(ipw.HBox, ipw.ValueWidget):
+    def __init__(
+        self,
+        dim: str,
+        start: float | None = None,
+        stop: float | None = None,
+        nbins: int = 1,
+        unit: str | None = "undefined",
+        log: bool = False,
+    ):
+        super().__init__()
+        style = {
+            "layout": {"width": "100px"},
+            "style": {"description_width": "initial"},
+        }
+        units = UNITS_LIBRARY[dim] if unit == "undefined" else unit
+        if isinstance(units, str):
+            units = {"options": (units,)}
+        self.fields = {
+            "dim": ipw.Label(str(dim)),
+            "unit": ipw.Dropdown(
+                options=units["options"],
+                value=units.get("selected", units["options"][0]),
+                layout={"width": "initial"},
+            ),
+            "start": ipw.FloatText(description='start:', value=start, **style),
+            "stop": ipw.FloatText(description='stop:', value=stop, **style),
+            "nbins": ipw.BoundedIntText(
+                description='nbins:', value=nbins, min=1, **style
+            ),
+            "spacing": ipw.Dropdown(
+                options=['linear', 'log'],
+                value='log' if log else 'linear',
+                layout={"width": "initial"},
+            ),
+        }
+        self.children = [
+            ipw.HTML(
+                f"Binning: &nbsp;&nbsp; <b>{self.fields['dim'].value}</b> "
+                "&nbsp;&nbsp; unit:"
+            )
+        ] + list(self.fields.values())[1:]
+
+    @property
+    def value(self) -> sc.Variable:
+        kwargs = {
+            "dim": self.fields['dim'].value,
+            "num": self.fields['nbins'].value + 1,
+            "unit": self.fields['unit'].value,
+            "start": self.fields['start'].value,
+            "stop": self.fields['stop'].value,
+        }
+
+        if self.fields["spacing"].value == "linear":
+            return sc.linspace(**kwargs)
+        else:
+            for key in ("start", "stop"):
+                kwargs[key] = np.log10(kwargs[key])
+            return sc.logspace(**kwargs)

--- a/src/ess/reduce/widgets/_binedges_widget.py
+++ b/src/ess/reduce/widgets/_binedges_widget.py
@@ -23,6 +23,7 @@ UNITS_LIBRARY = {
 class BinEdgesWidget(ipw.HBox, ipw.ValueWidget):
     def __init__(
         self,
+        name: str,
         dim: str,
         start: float | None = None,
         stop: float | None = None,
@@ -56,12 +57,7 @@ class BinEdgesWidget(ipw.HBox, ipw.ValueWidget):
                 layout={"width": "initial"},
             ),
         }
-        self.children = [
-            ipw.HTML(
-                f"Binning: &nbsp;&nbsp; <b>{self.fields['dim'].value}</b> "
-                "&nbsp;&nbsp; unit:"
-            )
-        ] + list(self.fields.values())[1:]
+        self.children = [ipw.Label(f"{name}:")] + list(self.fields.values())[1:]
 
     @property
     def value(self) -> sc.Variable:

--- a/src/ess/reduce/widgets/_binedges_widget.py
+++ b/src/ess/reduce/widgets/_binedges_widget.py
@@ -39,6 +39,8 @@ class BinEdgesWidget(ipw.HBox, ipw.ValueWidget):
         units = UNITS_LIBRARY[dim] if unit == "undefined" else unit
         if isinstance(units, str):
             units = {"options": (units,)}
+        if not isinstance(units, dict):
+            units = {"options": units}
         self.fields = {
             "dim": ipw.Label(str(dim)),
             "unit": ipw.Dropdown(

--- a/src/ess/reduce/widgets/_binedges_widget.py
+++ b/src/ess/reduce/widgets/_binedges_widget.py
@@ -63,17 +63,11 @@ class BinEdgesWidget(ipw.HBox, ipw.ValueWidget):
 
     @property
     def value(self) -> sc.Variable:
-        kwargs = {
-            "dim": self.fields['dim'].value,
-            "num": self.fields['nbins'].value + 1,
-            "unit": self.fields['unit'].value,
-            "start": self.fields['start'].value,
-            "stop": self.fields['stop'].value,
-        }
-
-        if self.fields["spacing"].value == "linear":
-            return sc.linspace(**kwargs)
-        else:
-            for key in ("start", "stop"):
-                kwargs[key] = np.log10(kwargs[key])
-            return sc.logspace(**kwargs)
+        func = sc.geomspace if self.fields["spacing"].value == "log" else sc.linspace
+        return func(
+            dim=self.fields["dim"].value,
+            start=self.fields["start"].value,
+            stop=self.fields["stop"].value,
+            num=self.fields["nbins"].value + 1,
+            unit=self.fields["unit"].value,
+        )

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -296,6 +296,7 @@ def test_workflow_selection() -> None:
 WavelengthBins = NewType('WavelengthBins', sc.Variable)
 WavelengthBinsWithUnit = NewType('WavelengthBinsWithUnit', sc.Variable)
 QBins = NewType('QBins', sc.Variable)
+TemperatureBinsWithUnits = NewType('TemperatureBinsWithUnits', sc.Variable)
 
 
 parameter_registry[WavelengthBins] = BinEdgesParameter(WavelengthBins, dim='wavelength')
@@ -304,6 +305,9 @@ parameter_registry[WavelengthBinsWithUnit] = BinEdgesParameter(
 )
 parameter_registry[QBins] = BinEdgesParameter(
     QBins, dim='Q', start=0.01, stop=0.6, nbins=150
+)
+parameter_registry[TemperatureBinsWithUnits] = BinEdgesParameter(
+    TemperatureBinsWithUnits, dim='temperature', unit=('Kelvin', 'Celsius', 'Degrees')
 )
 
 
@@ -316,6 +320,10 @@ def wavelength_bins_with_unit_print_provider(bins: WavelengthBinsWithUnit) -> st
 
 
 def q_bins_print_provider(bins: QBins) -> str:
+    return str(bins)
+
+
+def temperature_bins_print_provider(bins: TemperatureBinsWithUnits) -> str:
     return str(bins)
 
 
@@ -352,6 +360,18 @@ def test_bin_edges_widget_override_unit() -> None:
     )
     assert set(param_widget.fields['unit'].options) == {'m'}
     assert param_widget.fields['nbins'].value == 1
+
+
+def test_bin_edges_widget_override_unit_multiple() -> None:
+    widget = _ready_widget(
+        providers=[temperature_bins_print_provider], output_selections=[str]
+    )
+    param_widget = _get_param_widget(widget, TemperatureBinsWithUnits)
+    assert sc.identical(
+        param_widget.value,
+        sc.linspace(dim='temperature', start=0.0, stop=0.0, num=2, unit='Kelvin'),
+    )
+    assert set(param_widget.fields['unit'].options) == {'Kelvin', 'Celsius', 'Degrees'}
 
 
 def test_bin_edges_widget_log_spacing() -> None:

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -385,7 +385,7 @@ def test_bin_edges_widget_log_spacing() -> None:
     param_widget.fields['nbins'].value = 7
     assert sc.identical(
         param_widget.value,
-        sc.logspace(dim='wavelength', start=3, stop=5, num=8, unit='angstrom'),
+        sc.geomspace(dim='wavelength', start=1.0e3, stop=1.0e5, num=8, unit='angstrom'),
     )
     assert param_widget.fields['spacing'].value == 'log'
 


### PR DESCRIPTION
Make a widget for bin edges.
Fixes #59 

Examples:
```Py
# By default, unit is deduced from dim
parameter_registry[WavelengthBins] = BinEdgesParameter(
    WavelengthBins, dim='wavelength'
)
```
![Screenshot at 2024-09-27 15-24-07](https://github.com/user-attachments/assets/900b45e0-0a68-4117-ab34-c8301dce9de7)

```Py
# Overriding the unit
parameter_registry[WavelengthBins] = BinEdgesParameter(
    WavelengthBins, dim='wavelength', unit='m'
)
```
![Screenshot at 2024-09-27 15-26-17](https://github.com/user-attachments/assets/87c73ee6-79a2-4bd9-9b74-faee77b0ce80)

```Py
# Supplying default values
parameter_registry[WavelengthBins] = BinEdgesParameter(
    WavelengthBins, dim='wavelength', start=0.01, stop=12.0, nbins=300, log=True
)
```
![Screenshot at 2024-09-27 15-27-34](https://github.com/user-attachments/assets/af34fafe-3986-4807-8be5-cd75c35fd1ca)
