### PR TITLE
Adapt NeXus workflow to default to sample at the origin if sample group has no position

### DIFF
--- a/src/ess/reduce/nexus/workflow.py
+++ b/src/ess/reduce/nexus/workflow.py
@@ -147,7 +147,9 @@ def load_nexus_sample(
     try:
         dg = nexus.load_component(location, nx_class=snx.NXsample)
     except ValueError:
-        dg = sc.DataGroup(depends_on=snx.TransformationChain(parent='', value='.'))
+        dg = sc.DataGroup()
+    if 'depends_on' not in dg:
+        dg['depends_on'] = snx.TransformationChain(parent='', value='.')
     return NeXusComponent[snx.NXsample, RunType](dg)
 
 

--- a/tests/nexus/workflow_test.py
+++ b/tests/nexus/workflow_test.py
@@ -62,6 +62,22 @@ def test_can_compute_position_of_group(depends_on: snx.TransformationChain) -> N
     assert_identical(workflow.compute_position(trans), position)
 
 
+def test_given_no_sample_load_nexus_sample_returns_group_with_origin_depends_on() -> (
+    None
+):
+    filespec = workflow.file_path_to_file_spec(
+        data.loki_tutorial_sample_run_60250(), preopen=True
+    )
+    spec = workflow.unique_component_spec(filespec)
+    assert spec.filename['/entry'][snx.NXsample] == {}
+    sample = workflow.load_nexus_sample(spec)
+    assert list(sample) == ['depends_on']
+    chain = workflow.get_transformation_chain(sample)
+    transformation = workflow.to_transformation(chain)
+    position = workflow.compute_position(transformation)
+    assert_identical(position, sc.vector([0.0, 0.0, 0.0], unit='m'))
+
+
 def test_get_transformation_chain_raises_exception_if_position_not_found(
     group_with_no_position,
 ) -> None:


### PR DESCRIPTION
Previously we created a default sample at the origin if not found in the file. With this change, we handle the case where a sample group is present but without position. Defaulting to origin there as well.