### PR TITLE
Do not require valid transform chain when building live.raw.LogicalView

### DIFF
--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -151,6 +151,10 @@ class Detector:
 
     def bincount(self, data: Sequence[int]) -> sc.DataArray:
         offset = np.asarray(data, dtype=np.int32) - self._start
+        # Ignore events with detector numbers outside the range of the detector. This
+        # should not happen in valid files but for now it is useful until we are sure
+        # we get only valid files from upstream.
+        offset = offset[(offset >= 0) & (offset < self._size)]
         out = sc.empty_like(self.data)
         out.values = np.bincount(offset, minlength=self._size).reshape(self.data.shape)
         return out

--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -281,6 +281,7 @@ class RollingDetectorView(Detector):
         wf[RollingDetectorViewWindow] = window
         if isinstance(projection, LogicalView):
             wf[LogicalView] = projection
+            wf[NeXusTransformation[snx.NXdetector, SampleRun]] = sc.scalar(1)
             wf.insert(RollingDetectorView.from_detector_and_logical_view)
         elif projection == 'cylinder_mantle_z':
             wf.insert(make_cylinder_mantle_coords)

--- a/tests/live/raw_test.py
+++ b/tests/live/raw_test.py
@@ -17,6 +17,16 @@ def test_clear_counts_resets_counts_to_zero() -> None:
     assert det.data.sum().value == 0
 
 
+def test_Detector_bincount_drops_out_of_range_ids() -> None:
+    detector_number = sc.array(dims=['pixel'], values=[1, 2, 3], unit=None)
+    det = raw.Detector(detector_number)
+    counts = det.bincount([1, 2, 0, -1, 3, 4])
+    assert sc.identical(
+        counts.data,
+        sc.array(dims=['pixel'], values=[1, 1, 1], unit='counts', dtype='int32'),
+    )
+
+
 def test_RollingDetectorView_full_window() -> None:
     detector_number = sc.array(dims=['pixel'], values=[1, 2, 3], unit=None)
     det = raw.RollingDetectorView(detector_number=detector_number, window=2)


### PR DESCRIPTION
We would like this to work with files from CODA, and some of them do not have valid chains (NMX). This sets a dummy transform to avoid errors when computing keys that depend on `CalibratedDetector`.