### PR TITLE
Fix NeXus workflow for pure rotations on detectors

### DIFF
--- a/src/ess/reduce/nexus/workflow.py
+++ b/src/ess/reduce/nexus/workflow.py
@@ -345,7 +345,11 @@ def get_calibrated_detector(
     # by the x/y/z offsets.
     offsets = snx.zip_pixel_offsets(da.coords).transpose(da.dims).copy()
     # We use the unit of the offsets as this is likely what the user expects.
-    position = transform.value.to(unit=offsets.unit) * offsets
+    if transform.value.unit is not None and transform.value.unit != '':
+        transform_value = transform.value.to(unit=offsets.unit)
+    else:
+        transform_value = transform.value
+    position = transform_value * offsets
     return CalibratedDetector[RunType](
         da.assign_coords(position=position + offset.to(unit=position.unit))
     )

--- a/tests/nexus/workflow_test.py
+++ b/tests/nexus/workflow_test.py
@@ -282,9 +282,17 @@ def test_get_calibrated_detector_position_dims_matches_data_dims(
     assert detector.coords['position'].sizes == {'y': 2, 'x': 3}
 
 
+@pytest.mark.parametrize(
+    'transform_value',
+    [
+        sc.spatial.translation(value=[1.0, 2.0, 3.0], unit='m'),
+        sc.spatial.rotations_from_rotvecs(sc.vector([0.1, 0.2, 0.3], unit='rad')),
+    ],
+)
 def test_get_calibrated_detector_position_unit_matches_offset_unit(
-    nexus_detector, transform
+    nexus_detector, transform_value
 ) -> None:
+    transform = NeXusTransformation(transform_value)
     nexus_detector['data'].coords['x_pixel_offset'] = (
         nexus_detector['data'].coords['x_pixel_offset'].to(unit='mm')
     )


### PR DESCRIPTION
I introduced this in #126 (which fixed a problem of mismatching length units).