### PR TITLE
Add missing instantiation of NeXusTransformation in ess.reduce.live.raw

### DIFF
--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -285,7 +285,9 @@ class RollingDetectorView(Detector):
         wf[RollingDetectorViewWindow] = window
         if isinstance(projection, LogicalView):
             wf[LogicalView] = projection
-            wf[NeXusTransformation[snx.NXdetector, SampleRun]] = sc.scalar(1)
+            wf[NeXusTransformation[snx.NXdetector, SampleRun]] = NeXusTransformation[
+                snx.NXdetector, SampleRun
+            ](sc.scalar(1))
             wf.insert(RollingDetectorView.from_detector_and_logical_view)
         elif projection == 'cylinder_mantle_z':
             wf.insert(make_cylinder_mantle_coords)


### PR DESCRIPTION
This is an example of the problems we discussed a while ago, relating to Sciline not being able to check the types. I don't know if anyone has thought of a solution by now?