### PR TITLE
Make enum widgets show value and parameter name clearly

### DIFF
--- a/src/ess/reduce/parameter.py
+++ b/src/ess/reduce/parameter.py
@@ -71,7 +71,12 @@ class ParamWithOptions(Parameter[T]):
 
     @classmethod
     def from_enum(cls: type[C], t: type[T], default: T) -> C:
-        return cls(name=str(t), description=t.__doc__, options=t, default=default)
+        return cls(
+            name=t.__name__,
+            description=t.__doc__,
+            options=t.__members__,
+            default=default,
+        )
 
 
 @dataclass


### PR DESCRIPTION
Changes 
<img width="653" alt="Screenshot 2024-12-04 at 2 11 42 PM" src="https://github.com/user-attachments/assets/d7a54178-c0db-4315-af42-7ec0775b10ca">

to 

<img width="650" alt="Screenshot 2024-12-04 at 2 10 25 PM" src="https://github.com/user-attachments/assets/db8d3d84-6c84-490c-a6c4-9d8bb9d4aa77">
