### PR TITLE
Extract function to prune type vars in workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ addopts = """
 testpaths = "tests"
 filterwarnings = [
   "error",
+  # Plotting related warnings.
+  'ignore:\n            Sentinel is not a public part of the traitlets API:DeprecationWarning',
 ]
 
 [tool.ruff]

--- a/src/ess/reduce/nexus/workflow.py
+++ b/src/ess/reduce/nexus/workflow.py
@@ -10,8 +10,8 @@ from typing import Any
 import networkx as nx
 import sciline
 import scipp as sc
+import scipp.constants
 import scippnexus as snx
-from scipp.constants import g
 from scipp.core import label_based_index_to_positional_index
 from scippneutron.chopper import extract_chopper_from_nexus
 
@@ -80,7 +80,7 @@ def gravity_vector_neg_y() -> GravityVector:
     """
     Gravity vector for default instrument coordinate system where y is up.
     """
-    return GravityVector(sc.vector(value=[0, -1, 0]) * g)
+    return GravityVector(sc.vector(value=[0, -1, 0]) * sc.constants.g)
 
 
 def component_spec_by_name(

--- a/tests/nexus/nexus_workflow_test.py
+++ b/tests/nexus/nexus_workflow_test.py
@@ -9,15 +9,11 @@ from ess.reduce import data
 from ess.reduce.nexus import compute_component_position, workflow
 from ess.reduce.nexus.types import (
     Analyzers,
-    BackgroundRun,
     Choppers,
     DetectorData,
     Filename,
     Monitor1,
-    Monitor2,
-    Monitor3,
     MonitorData,
-    NeXusComponentLocationSpec,
     NeXusName,
     NeXusTransformation,
     SampleRun,
@@ -27,7 +23,6 @@ from ess.reduce.nexus.workflow import (
     GenericNeXusWorkflow,
     LoadDetectorWorkflow,
     LoadMonitorWorkflow,
-    prune_nexus_domain_types,
 )
 
 
@@ -573,32 +568,3 @@ def test_generic_nexus_workflow_load_analyzers() -> None:
     assert 'position' in analyzer
     assert analyzer['d_spacing'].ndim == 0
     assert analyzer['usage'] == 'Bragg'
-
-
-def test_pruning_nexus_workflow_includes_only_given_run_and_monitor_types() -> None:
-    wf = GenericNeXusWorkflow()
-    wf = prune_nexus_domain_types(
-        wf, run_types=[SampleRun], monitor_types=[Monitor1, Monitor3]
-    )
-    graph = wf.underlying_graph
-    assert DetectorData[SampleRun] in graph
-    assert DetectorData[BackgroundRun] not in graph
-    assert MonitorData[SampleRun, Monitor1] in graph
-    assert MonitorData[SampleRun, Monitor2] not in graph
-    assert MonitorData[SampleRun, Monitor3] in graph
-    assert MonitorData[BackgroundRun, Monitor1] not in graph
-    assert MonitorData[BackgroundRun, Monitor2] not in graph
-    assert MonitorData[BackgroundRun, Monitor3] not in graph
-    # Many other keys are also removed, this is just an example
-    assert NeXusComponentLocationSpec[Monitor1, SampleRun] in graph
-    assert NeXusComponentLocationSpec[Monitor2, SampleRun] not in graph
-    assert NeXusComponentLocationSpec[Monitor3, SampleRun] in graph
-    assert NeXusComponentLocationSpec[snx.NXdetector, SampleRun] in graph
-    assert NeXusComponentLocationSpec[snx.NXsample, SampleRun] in graph
-    assert NeXusComponentLocationSpec[snx.NXsource, SampleRun] in graph
-    assert NeXusComponentLocationSpec[Monitor1, BackgroundRun] not in graph
-    assert NeXusComponentLocationSpec[Monitor2, BackgroundRun] not in graph
-    assert NeXusComponentLocationSpec[Monitor3, BackgroundRun] not in graph
-    assert NeXusComponentLocationSpec[snx.NXdetector, BackgroundRun] not in graph
-    assert NeXusComponentLocationSpec[snx.NXsample, BackgroundRun] not in graph
-    assert NeXusComponentLocationSpec[snx.NXsource, BackgroundRun] not in graph

--- a/tests/nexus/workflow_test.py
+++ b/tests/nexus/workflow_test.py
@@ -27,6 +27,7 @@ from ess.reduce.nexus.workflow import (
     GenericNeXusWorkflow,
     LoadDetectorWorkflow,
     LoadMonitorWorkflow,
+    prune_nexus_domain_types,
 )
 
 
@@ -574,15 +575,11 @@ def test_generic_nexus_workflow_load_analyzers() -> None:
     assert analyzer['usage'] == 'Bragg'
 
 
-def test_generic_nexus_workflow_raises_if_monitor_types_but_not_run_types_given() -> (
-    None
-):
-    with pytest.raises(ValueError, match='run_types'):
-        GenericNeXusWorkflow(monitor_types=[Monitor1])
-
-
-def test_generic_nexus_workflow_includes_only_given_run_and_monitor_types() -> None:
-    wf = GenericNeXusWorkflow(run_types=[SampleRun], monitor_types=[Monitor1, Monitor3])
+def test_pruning_nexus_workflow_includes_only_given_run_and_monitor_types() -> None:
+    wf = GenericNeXusWorkflow()
+    wf = prune_nexus_domain_types(
+        wf, run_types=[SampleRun], monitor_types=[Monitor1, Monitor3]
+    )
     graph = wf.underlying_graph
     assert DetectorData[SampleRun] in graph
     assert DetectorData[BackgroundRun] not in graph

--- a/tests/workflow_test.py
+++ b/tests/workflow_test.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import pytest
+import scippnexus as snx
+from sciline import Pipeline, Scope
+
+from ess.reduce.nexus.types import (
+    BackgroundRun,
+    DetectorData,
+    EmptyBeamRun,
+    IncidentMonitor,
+    Monitor1,
+    Monitor2,
+    Monitor3,
+    Monitor4,
+    Monitor5,
+    Monitor6,
+    MonitorData,
+    NeXusComponentLocationSpec,
+    RunType,
+    SampleRun,
+    TransmissionMonitor,
+)
+from ess.reduce.nexus.workflow import (
+    GenericNeXusWorkflow,
+)
+from ess.reduce.workflow import prune_nexus_domain_types
+
+
+class A(Scope[RunType, int], int): ...
+
+
+class B(Scope[RunType, int], int): ...
+
+
+class C(Scope[RunType, int], int): ...
+
+
+class D(Scope[RunType, int], int): ...
+
+
+def foo(a: A[RunType]) -> B[RunType]:
+    return B[RunType](a + 1)
+
+
+def bar(a: A[RunType]) -> C[RunType]:
+    return C[RunType](a + 2)
+
+
+def baz(a: A[RunType]) -> D[RunType]:
+    return D[RunType](a + 3)
+
+
+def test_pruning_nexus_workflow_includes_only_given_run_types() -> None:
+    wf = GenericNeXusWorkflow()
+    wf = prune_nexus_domain_types(
+        wf,
+        targets_per_run=[DetectorData],
+        targets_per_run_and_monitor=[MonitorData],
+        run_types=[SampleRun],
+    )
+    graph = wf.underlying_graph
+    assert DetectorData[SampleRun] in graph
+    assert DetectorData[BackgroundRun] not in graph
+    assert MonitorData[SampleRun, Monitor1] in graph
+    assert MonitorData[SampleRun, Monitor2] in graph
+    assert MonitorData[SampleRun, Monitor3] in graph
+    assert MonitorData[BackgroundRun, Monitor1] not in graph
+    assert MonitorData[BackgroundRun, Monitor2] not in graph
+    assert MonitorData[BackgroundRun, Monitor3] not in graph
+    assert NeXusComponentLocationSpec[Monitor1, SampleRun] in graph
+    assert NeXusComponentLocationSpec[Monitor2, SampleRun] in graph
+    assert NeXusComponentLocationSpec[Monitor3, SampleRun] in graph
+    assert NeXusComponentLocationSpec[snx.NXdetector, SampleRun] in graph
+    assert NeXusComponentLocationSpec[snx.NXsample, SampleRun] in graph
+    assert NeXusComponentLocationSpec[snx.NXsource, SampleRun] in graph
+    assert NeXusComponentLocationSpec[Monitor1, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[Monitor2, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[Monitor3, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[snx.NXdetector, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[snx.NXsample, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[snx.NXsource, BackgroundRun] not in graph
+
+
+def test_pruning_nexus_workflow_includes_only_given_run_and_monitor_types() -> None:
+    wf = GenericNeXusWorkflow()
+    wf = prune_nexus_domain_types(
+        wf,
+        targets_per_run=[DetectorData],
+        targets_per_run_and_monitor=[MonitorData],
+        run_types=[SampleRun],
+        monitor_types=[Monitor1, Monitor3],
+    )
+    graph = wf.underlying_graph
+    assert DetectorData[SampleRun] in graph
+    assert DetectorData[BackgroundRun] not in graph
+    assert MonitorData[SampleRun, Monitor1] in graph
+    assert MonitorData[SampleRun, Monitor2] not in graph
+    assert MonitorData[SampleRun, Monitor3] in graph
+    assert MonitorData[BackgroundRun, Monitor1] not in graph
+    assert MonitorData[BackgroundRun, Monitor2] not in graph
+    assert MonitorData[BackgroundRun, Monitor3] not in graph
+    assert NeXusComponentLocationSpec[Monitor1, SampleRun] in graph
+    assert NeXusComponentLocationSpec[Monitor2, SampleRun] not in graph
+    assert NeXusComponentLocationSpec[Monitor3, SampleRun] in graph
+    assert NeXusComponentLocationSpec[snx.NXdetector, SampleRun] in graph
+    assert NeXusComponentLocationSpec[snx.NXsample, SampleRun] in graph
+    assert NeXusComponentLocationSpec[snx.NXsource, SampleRun] in graph
+    assert NeXusComponentLocationSpec[Monitor1, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[Monitor2, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[Monitor3, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[snx.NXdetector, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[snx.NXsample, BackgroundRun] not in graph
+    assert NeXusComponentLocationSpec[snx.NXsource, BackgroundRun] not in graph
+
+
+def test_pruning_nexus_workflow_includes_all_monitor_types_by_default() -> None:
+    wf = GenericNeXusWorkflow()
+    wf = prune_nexus_domain_types(
+        wf,
+        targets_per_run=[],
+        targets_per_run_and_monitor=[MonitorData],
+        run_types=[SampleRun],
+    )
+    graph = wf.underlying_graph
+    assert MonitorData[SampleRun, Monitor1] in graph
+    assert MonitorData[SampleRun, Monitor2] in graph
+    assert MonitorData[SampleRun, Monitor3] in graph
+    assert MonitorData[SampleRun, Monitor4] in graph
+    assert MonitorData[SampleRun, Monitor5] in graph
+    assert MonitorData[SampleRun, Monitor6] in graph
+    assert MonitorData[SampleRun, IncidentMonitor] in graph
+    assert MonitorData[SampleRun, TransmissionMonitor] in graph
+    assert MonitorData[BackgroundRun, Monitor1] not in graph
+    assert MonitorData[BackgroundRun, Monitor2] not in graph
+    assert MonitorData[BackgroundRun, Monitor3] not in graph
+    assert MonitorData[BackgroundRun, Monitor4] not in graph
+    assert MonitorData[BackgroundRun, Monitor5] not in graph
+    assert MonitorData[BackgroundRun, Monitor6] not in graph
+    assert MonitorData[BackgroundRun, IncidentMonitor] not in graph
+    assert MonitorData[BackgroundRun, TransmissionMonitor] not in graph
+
+
+def test_pruning_workflow_includes_multiple_targets() -> None:
+    wf = Pipeline((foo, bar, baz))
+    wf = prune_nexus_domain_types(
+        wf,
+        targets_per_run=[B, C],
+        run_types=[SampleRun],
+    )
+    graph = wf.underlying_graph
+    assert A[SampleRun] in graph
+    assert B[SampleRun] in graph
+    assert C[SampleRun] in graph
+    assert D[SampleRun] not in graph
+    assert A[BackgroundRun] not in graph
+    assert B[BackgroundRun] not in graph
+    assert C[BackgroundRun] not in graph
+    assert D[BackgroundRun] not in graph
+    assert A[EmptyBeamRun] not in graph
+    assert B[EmptyBeamRun] not in graph
+    assert C[EmptyBeamRun] not in graph
+    assert D[EmptyBeamRun] not in graph
+
+
+def test_pruning_workflow_includes_multiple_run_types() -> None:
+    wf = Pipeline((foo, bar, baz))
+    wf = prune_nexus_domain_types(
+        wf,
+        targets_per_run=[B, C],
+        run_types=[SampleRun, BackgroundRun],
+    )
+    graph = wf.underlying_graph
+    assert A[SampleRun] in graph
+    assert B[SampleRun] in graph
+    assert C[SampleRun] in graph
+    assert D[SampleRun] not in graph
+    assert A[BackgroundRun] in graph
+    assert B[BackgroundRun] in graph
+    assert C[BackgroundRun] in graph
+    assert D[BackgroundRun] not in graph
+    assert A[EmptyBeamRun] not in graph
+    assert B[EmptyBeamRun] not in graph
+    assert C[EmptyBeamRun] not in graph
+    assert D[EmptyBeamRun] not in graph
+
+
+def test_pruning_nexus_workflow_requires_monitor_targets_if_monitor_types_given() -> (
+    None
+):
+    wf = GenericNeXusWorkflow()
+    with pytest.raises(ValueError, match='targets_per_run_and_monitor'):
+        prune_nexus_domain_types(
+            wf,
+            targets_per_run=[DetectorData],
+            run_types=[SampleRun],
+            monitor_types=[Monitor1, Monitor3],
+        )


### PR DESCRIPTION
When building a concrete workflow, we usually modify the result of `GenericNeXusWorkflow()`. This reintroduces run types and monitor types that are excluded by `run_types` and `monitor_types`.

Extracting `prune_nexus_domain_types` into its own function allows us to remove unused types after inserting custom providers into the workflow.