### PR TITLE
Fix multifile widget init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ addopts = """
 testpaths = "tests"
 filterwarnings = [
   "error",
+  'ignore:\n            Sentinel is not a public part of the traitlets API:DeprecationWarning',
 ]
 
 [tool.ruff]

--- a/src/ess/reduce/widgets/_string_widget.py
+++ b/src/ess/reduce/widgets/_string_widget.py
@@ -27,6 +27,15 @@ class StringWidget(HBox, ValueWidget):
 
 
 class MultiStringWidget(StringWidget):
+    def __init__(
+        self, description: str, value: tuple[str, ...] | None = None, **kwargs
+    ):
+        # Special case handling to allow initialising with a single string
+        if not isinstance(value, str) and value is not None:
+            value = ', '.join(value)
+
+        super().__init__(description, value, **kwargs)
+
     @property
     def value(self) -> tuple[str, ...]:
         v = super().value

--- a/tests/widget_test.py
+++ b/tests/widget_test.py
@@ -9,7 +9,13 @@ import sciline as sl
 import scipp as sc
 from ipywidgets import FloatText, IntText
 
-from ess.reduce.parameter import BinEdgesParameter, Parameter, parameter_registry
+from ess.reduce.parameter import (
+    BinEdgesParameter,
+    FilenameParameter,
+    MultiFilenameParameter,
+    Parameter,
+    parameter_registry,
+)
 from ess.reduce.ui import ResultBox, WorkflowWidget, workflow_widget
 from ess.reduce.widgets import OptionalWidget, SwitchWidget, create_parameter_widget
 from ess.reduce.workflow import register_workflow, workflow_registry
@@ -423,3 +429,51 @@ def test_result_box_can_handle_different_outputs(output):
 
     ResultBox(run_workflow).run_button.click()
     assert was_called
+
+
+FilenameSampleRun = NewType('FilenameSampleRun', str)
+parameter_registry[FilenameSampleRun] = FilenameParameter.from_type(
+    FilenameSampleRun, default="SampleRun.hdf"
+)
+MultiFilenameSampleRun = NewType('MultiFilenameSampleRun', list[str])
+parameter_registry[MultiFilenameSampleRun] = MultiFilenameParameter.from_type(
+    MultiFilenameSampleRun, default=["file1.hdf", "file2.hdf"]
+)
+MultiFilenameBackgroundRun = NewType('MultiFilenameBackgroundRun', list[str])
+parameter_registry[MultiFilenameBackgroundRun] = MultiFilenameParameter.from_type(
+    MultiFilenameBackgroundRun, default="background.hdf"
+)
+
+
+def filename_print_provider(fname: FilenameSampleRun) -> str:
+    return str(fname)
+
+
+def multi_filename_print_provider(fnames: MultiFilenameSampleRun) -> list[str]:
+    return [str(fname) for fname in fnames]
+
+
+def multi_filename_print_provider_bis(fnames: MultiFilenameBackgroundRun) -> list[str]:
+    return [str(fname) for fname in fnames]
+
+
+def test_filename_widget_single() -> None:
+    widget = _ready_widget(providers=[filename_print_provider], output_selections=[str])
+    param_widget = _get_param_widget(widget, FilenameSampleRun)
+    assert param_widget.value == "SampleRun.hdf"
+
+
+def test_filename_widget_multiple() -> None:
+    widget = _ready_widget(
+        providers=[multi_filename_print_provider], output_selections=[list[str]]
+    )
+    param_widget = _get_param_widget(widget, MultiFilenameSampleRun)
+    assert param_widget.value == ("file1.hdf", "file2.hdf")
+
+
+def test_filename_widget_multiple_initialized_with_single_string() -> None:
+    widget = _ready_widget(
+        providers=[multi_filename_print_provider_bis], output_selections=[list[str]]
+    )
+    param_widget = _get_param_widget(widget, MultiFilenameBackgroundRun)
+    assert param_widget.value == ("background.hdf",)


### PR DESCRIPTION
This allows to initialise the MultiFilename widget with both a single string and a list of strings.