### PR TITLE
Add ROIFilter

### DIFF
--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -528,9 +528,12 @@ def position_noise_for_cylindrical_pixel(
 
 
 def gaussian_position_noise(sigma: PositionNoiseSigma) -> PositionNoise:
+    sigma = sigma.to(unit='m', copy=False)
     size = _noise_size
     position = sc.empty(sizes={'position': size}, unit='m', dtype=sc.DType.vector3)
-    position.values = np.random.default_rng().normal(0, sigma.value, size=(size, 3))
+    position.values = np.random.default_rng(seed=1234).normal(
+        0, sigma.value, size=(size, 3)
+    )
     return PositionNoise(position)
 
 

--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -243,7 +243,15 @@ class RollingDetectorView(Detector):
         self._current = 0
         self._history: sc.DataArray | None = None
         self._cache: sc.DataArray | None = None
+        self.clear_counts()
 
+    def clear_counts(self) -> None:
+        """
+        Clear counts.
+
+        Overrides Detector.clear_counts, to properly clear sliding window history and
+        cache.
+        """
         counts = sc.zeros_like(self.data)
         if self._projection is not None:
             counts = self._projection(counts)

--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -110,7 +110,8 @@ class Histogrammer:
     def __call__(self, da: sc.DataArray) -> sc.DataArray:
         self._current += 1
         coords = self._coords[self._replica_dim, self._current % self._replicas]
-        return sc.DataArray(da.data, coords=coords).hist(self._edges)
+        # If input is multi-dim we need to flatten since those dims cannot be preserved.
+        return sc.DataArray(da.data, coords=coords).flatten(to='_').hist(self._edges)
 
     def input_indices(self) -> sc.DataArray:
         """Return an array with input indices corresponding to each histogram bin."""
@@ -247,6 +248,7 @@ class RollingDetectorView(Detector):
         self._cache = self._history.sum('window')
 
     def make_roi_filter(self) -> roi.ROIFilter:
+        """Return a ROI filter operating via the projection plane of the view."""
         norm = 1.0
         if isinstance(self._projection, Histogrammer):
             indices = self._projection.input_indices()

--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -170,6 +170,7 @@ class Detector:
             sc.zeros(sizes=detector_number.sizes, unit='counts', dtype='int32'),
             coords={'detector_number': detector_number},
         )
+        self._detector_number = detector_number
         self._flat_detector_number = detector_number.flatten(to='event_id')
         self._start = int(self._flat_detector_number[0].value)
         self._stop = int(self._flat_detector_number[-1].value)
@@ -178,6 +179,10 @@ class Detector:
             raise ValueError("Detector numbers must be sorted.")
         if self._stop - self._start + 1 != self._size:
             raise ValueError("Detector numbers must be consecutive.")
+
+    @property
+    def detector_number(self) -> sc.Variable:
+        return self._detector_number
 
     @property
     def data(self) -> sc.DataArray:

--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -368,8 +368,32 @@ class RollingDetectorView(Detector):
                 data += self._history['window', 0 : self._current].sum('window')
         return data
 
+    def add_events(self, data: sc.DataArray) -> None:
+        """
+        Add counts in the form of events grouped by pixel ID.
+
+        Parameters
+        ----------
+        data:
+            Events grouped by pixel ID, given by binned data.
+        """
+        counts = data.bins.size().to(dtype='int32', copy=False)
+        counts.unit = 'counts'
+        self._add_counts(counts)
+
     def add_counts(self, data: Sequence[int]) -> None:
+        """
+        Add counts in the form of a sequence of pixel IDs.
+
+        Parameters
+        ----------
+        data:
+            List of pixel IDs.
+        """
         counts = self.bincount(data)
+        self._add_counts(counts)
+
+    def _add_counts(self, counts: sc.Variable) -> None:
         if self._projection is not None:
             counts = self._projection(counts)
         self._cache -= self._history['window', self._current]

--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -104,6 +104,17 @@ class Histogrammer:
         coords = self._coords[self._replica_dim, self._current % self._replicas]
         return sc.DataArray(da.data, coords=coords).hist(self._edges)
 
+    def input_indices(self) -> sc.Variable:
+        """Return an array with input indices corresponding to each histogram bin."""
+        dim = 'detector_number'
+        coords = self._coords.broadcast(sizes=self._coords.sizes).flatten(to=dim)
+        ndet = sc.index(coords.sizes[dim] // self._replicas)
+        da = sc.DataArray(
+            sc.arange(dim, coords.sizes[dim], dtype='int64', unit=None) % ndet,
+            coords=coords,
+        )
+        return da.bin(self._edges).bins.data
+
 
 @dataclass
 class LogicalView:

--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -19,6 +19,8 @@ options:
   flatten dimensions of the data.
 """
 
+from __future__ import annotations
+
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from math import ceil
@@ -76,7 +78,7 @@ class Histogrammer:
     @staticmethod
     def from_coords(
         coords: ProjectedCoords, resolution: DetectorViewResolution
-    ) -> 'Histogrammer':
+    ) -> Histogrammer:
         """
         Create a histogrammer from coordinates and resolution.
 
@@ -113,7 +115,7 @@ class Histogrammer:
             sc.arange(dim, coords.sizes[dim], dtype='int64', unit=None) % ndet,
             coords=coords,
         )
-        return da.bin(self._edges).bins.data
+        return sc.DataArray(da.bin(self._edges).bins.data, coords=self._edges)
 
 
 @dataclass
@@ -242,7 +244,7 @@ class RollingDetectorView(Detector):
         detector: CalibratedDetector[SampleRun],
         window: RollingDetectorViewWindow,
         projection: Histogrammer,
-    ) -> 'RollingDetectorView':
+    ) -> RollingDetectorView:
         """Helper for constructing via a Sciline workflow."""
         return RollingDetectorView(
             detector_number=detector.coords['detector_number'],
@@ -255,7 +257,7 @@ class RollingDetectorView(Detector):
         detector: CalibratedDetector[SampleRun],
         window: RollingDetectorViewWindow,
         projection: LogicalView,
-    ) -> 'RollingDetectorView':
+    ) -> RollingDetectorView:
         """Helper for constructing via a Sciline workflow."""
         return RollingDetectorView(
             detector_number=detector.coords['detector_number'],
@@ -272,7 +274,7 @@ class RollingDetectorView(Detector):
         projection: Literal['xy_plane', 'cylinder_mantle_z'] | LogicalView,
         resolution: dict[str, int] | None = None,
         pixel_noise: Literal['cylindrical'] | sc.Variable | None = None,
-    ) -> 'RollingDetectorView':
+    ) -> RollingDetectorView:
         """
         Create a rolling detector view from a NeXus file using GenericNeXusWorkflow.
 

--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -115,7 +115,8 @@ class Histogrammer:
     def input_indices(self) -> sc.DataArray:
         """Return an array with input indices corresponding to each histogram bin."""
         dim = 'detector_number'
-        coords = self._coords.broadcast(sizes=self._coords.sizes).flatten(to=dim)
+        # For some projections one of the coords is a scalar, convert to flat table.
+        coords = self._coords.broadcast(sizes=self._coords.sizes).flatten(to=dim).copy()
         ndet = sc.index(coords.sizes[dim] // self._replicas)
         da = sc.DataArray(
             sc.arange(dim, coords.sizes[dim], dtype='int64', unit=None) % ndet,

--- a/src/ess/reduce/live/roi.py
+++ b/src/ess/reduce/live/roi.py
@@ -29,7 +29,8 @@ def select_indices_in_intervals(
         indices will be returned concatenated into a dense array.
     """
     out_dim = 'index'
-    for dim, (low, high) in intervals.items():
+    for dim, bounds in intervals.items():
+        low, high = sorted(bounds)
         indices = indices[dim, low:high]
     indices = indices.flatten(to=out_dim)
     if indices.bins is None:

--- a/src/ess/reduce/live/roi.py
+++ b/src/ess/reduce/live/roi.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Utilities for region of interest (ROI) selection."""
+
+from typing import TypeVar
+
+import numpy as np
+import scipp as sc
+
+
+def select_indices_in_intervals(
+    intervals: sc.DataGroup[tuple[int, int] | tuple[sc.Variable, sc.Variable]],
+    indices: sc.Variable | sc.DataArray,
+) -> sc.Variable:
+    """
+    Return subset of indices that fall within the intervals.
+
+    Parameters
+    ----------
+    intervals:
+        DataGroup with dimension names as keys and tuples of low and high values. This
+        can be used to define a band or a rectangle to selected. When low and high are
+        scipp.Variable, the selection is done using label-based indexing. In this case
+        `indices` must be a DataArray with corresponding coordinates.
+    indices:
+        Variable or DataArray with indices to select from. If binned data the selected
+        indices will be returned concatenated into a dense array.
+    """
+    out_dim = 'index'
+    for dim, (low, high) in intervals.items():
+        indices = indices[dim, low:high]
+    indices = indices.flatten(to=out_dim)
+    if indices.bins is None:
+        return indices
+    indices = indices.bins.concat().value
+    return indices.rename_dims({indices.dim: out_dim})
+
+
+T = TypeVar('T', sc.DataArray, sc.Variable)
+
+
+def apply_selection(data: T, *, selection: sc.Variable) -> T:
+    """
+    Apply selection to data.
+    """
+    indices, counts = np.unique(selection.values, return_counts=True)
+    scale = sc.array(dims=[data.dim], values=counts, dtype=data.dtype)
+    return data[indices] * scale

--- a/src/ess/reduce/live/roi.py
+++ b/src/ess/reduce/live/roi.py
@@ -75,4 +75,6 @@ class ROIFilter:
         self._roi = select_indices_in_intervals(intervals, self._indices)
 
     def apply(self, data: T) -> T:
+        if data.ndim != 1:
+            data = data.flatten(to='detector_number')
         return apply_selection(data, selection=self._roi)

--- a/src/ess/reduce/live/roi.py
+++ b/src/ess/reduce/live/roi.py
@@ -53,12 +53,28 @@ def apply_selection(data: T, *, selection: sc.Variable) -> T:
 
 
 class ROIFilter:
+    """Filter for selecting a region of interest (ROI)."""
+
     def __init__(self, indices: sc.Variable):
+        """
+        Create a new ROI filter.
+
+        Parameters
+        ----------
+        indices:
+            Variable with indices to filter. The indices facilitate selecting a 2-D
+            ROI in a projection of a 3-D dataset. Typically the indices are given by a
+            2-D array. Each element in the array may correspond to a single index (when
+            there is no projection) or a list of indices that were projected into an
+            output pixel.
+        """
         self._indices = indices
         self._selection = sc.array(dims=['index'], values=[])
 
     def set_roi_from_intervals(self, intervals: sc.DataGroup) -> None:
+        """Set the ROI from (typically 1 or 2) intervals."""
         self._selection = select_indices_in_intervals(intervals, self._indices)
 
     def apply(self, data: T) -> T:
+        """Apply the ROI filter to data."""
         return apply_selection(data, selection=self._selection)

--- a/tests/live/raw_test.py
+++ b/tests/live/raw_test.py
@@ -173,20 +173,20 @@ def make_grid_cube(
 
     Parameters
     ----------
-    nx : int, optional
+    nx:
         Number of points along x-axis, by default 5
-    ny : int, optional
+    ny:
         Number of points along y-axis, by default 5
-    nz : int, optional
+    nz:
         Number of points along z-axis, by default 5
-    center : tuple, optional
+    center:
         (x, y, z) coordinates of cube center, by default (0.0, 0.0, 10.0)
-    size : float, optional
+    size:
         Side length of cube in meters, by default 1.0
 
     Returns
     -------
-    sc.Variable
+    :
         Scipp variable containing grid points with shape (nx * ny * nz, 3)
 
     Examples

--- a/tests/live/raw_test.py
+++ b/tests/live/raw_test.py
@@ -7,6 +7,17 @@ import scipp as sc
 from ess.reduce.live import raw
 
 
+@pytest.mark.parametrize(
+    'sigma',
+    [sc.scalar(0.01, unit='m'), sc.scalar(1.0, unit='cm'), sc.scalar(10.0, unit='mm')],
+)
+def test_gaussian_position_noise_is_sigma_unit_independent(sigma: sc.Variable) -> None:
+    sigma_m = sigma.to(unit='m')
+    reference = raw.gaussian_position_noise(sigma=sigma_m)
+    noise = raw.gaussian_position_noise(sigma=sigma)
+    assert sc.identical(noise, reference)
+
+
 def test_clear_counts_resets_counts_to_zero() -> None:
     detector_number = sc.array(dims=['pixel'], values=[1, 2, 3], unit=None)
     det = raw.Detector(detector_number)

--- a/tests/live/raw_test.py
+++ b/tests/live/raw_test.py
@@ -107,6 +107,23 @@ def test_RollingDetectorView_partial_window() -> None:
     assert det.get(3).sum().value == 4
 
 
+def test_RollingDetectorView_clear_counts() -> None:
+    detector_number = sc.array(dims=['pixel'], values=[1, 2, 3], unit=None)
+    det = raw.RollingDetectorView(detector_number=detector_number, window=3)
+    det.add_counts([1, 2, 3, 2])
+    assert det.get(0).sum().value == 0
+    assert det.get(1).sum().value == 4
+    assert det.get(2).sum().value == 4
+    assert det.get(3).sum().value == 4
+    assert det.get().sum().value == 4
+    det.clear_counts()
+    assert det.get(0).sum().value == 0
+    assert det.get(1).sum().value == 0
+    assert det.get(2).sum().value == 0
+    assert det.get(3).sum().value == 0
+    assert det.get().sum().value == 0
+
+
 def test_RollingDetectorView_raises_if_subwindow_exceeds_window() -> None:
     detector_number = sc.array(dims=['pixel'], values=[1, 2, 3], unit=None)
     det = raw.RollingDetectorView(detector_number=detector_number, window=3)

--- a/tests/live/raw_test.py
+++ b/tests/live/raw_test.py
@@ -219,5 +219,6 @@ def test_histogrammer_input_indices() -> None:
     resolution = {'x': 4, 'y': 5}
     histogrammer = raw.Histogrammer.from_coords(coords=coords, resolution=resolution)
     indices = histogrammer.input_indices()
+    assert set(indices.coords) == {'x', 'y'}
     assert indices.bins.size().sum().value == nx * ny * nz
     assert indices.sizes == resolution

--- a/tests/live/roi_test.py
+++ b/tests/live/roi_test.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+import pytest
+import scipp as sc
+
+from ess.reduce.live import roi
+
+
+@pytest.fixture
+def binned_indices() -> sc.DataArray:
+    table = sc.data.table_xyz(123)
+    table.coords['index'] = (
+        10 * table.coords['x'] + 10 * table.coords['y'] + 10 * table.coords['z']
+    ).to(dtype='int32')
+    binned = table.bin(x=4, y=5)
+    return sc.DataArray(binned.bins.coords['index'], coords=binned.coords)
+
+
+def test_select_indices_positional_indexing(binned_indices):
+    selected = roi.select_indices_in_intervals(
+        intervals=sc.DataGroup(x=(1, 3), y=(2, 4)), indices=binned_indices
+    )
+    assert selected.dim == 'index'
+    assert selected.sizes[selected.dim] > 0
+    assert selected.sizes[selected.dim] < binned_indices.bins.size().sum().value
+
+
+def test_select_indices_label_based_indexing(binned_indices):
+    selected = roi.select_indices_in_intervals(
+        intervals=sc.DataGroup(x=(sc.scalar(0.3, unit='m'), sc.scalar(0.5, unit='m'))),
+        indices=binned_indices,
+    )
+    assert selected.dim == 'index'
+    assert selected.sizes[selected.dim] > 0
+    assert selected.sizes[selected.dim] < binned_indices.bins.size().sum().value
+
+
+def test_select_indices_fails_with_invalid_dimension():
+    data = sc.data.table_xyz(10)
+    with pytest.raises(sc.DimensionError):
+        roi.select_indices_in_intervals(
+            intervals=sc.DataGroup(invalid_dim=(1, 2)), indices=data
+        )
+
+
+def test_select_indices_fails_without_required_coords():
+    data = sc.DataArray(sc.array(dims=['x'], values=[1, 2, 3]))
+    with pytest.raises(sc.DimensionError, match='no coordinate for that dimension'):
+        roi.select_indices_in_intervals(
+            intervals=sc.DataGroup(
+                x=(sc.scalar(1.0, unit='m'), sc.scalar(2.0, unit='m'))
+            ),
+            indices=data,
+        )
+
+
+def test_apply_selection_empty_yields_empty_result():
+    selection = sc.array(dims=['index'], values=[], unit=None, dtype='int32')
+    data = sc.arange('detector_number', 12, dtype='int32')
+    result = roi.apply_selection(data, selection=selection)
+    assert sc.identical(
+        result, sc.array(dims=['detector_number'], values=[], dtype='int32')
+    )
+
+
+def test_apply_selection_single_value():
+    selection = sc.array(dims=['index'], values=[3], unit=None, dtype='int32')
+    data = sc.arange('detector_number', 5, dtype='int32')
+    result = roi.apply_selection(data, selection=selection)
+    assert sc.identical(
+        result, sc.array(dims=['detector_number'], values=[3], dtype='int32')
+    )
+
+
+def test_apply_selection_repeated_indices():
+    selection = sc.array(dims=['index'], values=[1, 1, 2, 1], unit=None, dtype='int32')
+    data = sc.arange('detector_number', 5, dtype='int32')
+    result = roi.apply_selection(data, selection=selection)
+    assert sc.identical(
+        result,
+        sc.array(dims=['detector_number'], values=[1, 2], dtype='int32')
+        * sc.array(dims=['detector_number'], values=[3, 1], dtype='int32'),
+    )
+
+
+def test_apply_selection_with_data_array():
+    selection = sc.array(dims=['index'], values=[0, 0, 2], unit=None, dtype='int32')
+    data = sc.DataArray(
+        data=sc.arange('detector_number', 3, dtype='float64'),
+        coords={'pos': sc.arange('detector_number', 3, unit='m', dtype='float64')},
+    )
+    result = roi.apply_selection(data, selection=selection)
+    expected = sc.DataArray(
+        data=sc.array(dims=['detector_number'], values=[0.0, 2.0], dtype='float64')
+        * sc.array(dims=['detector_number'], values=[2, 1], dtype='float64'),
+        coords={'pos': sc.array(dims=['detector_number'], values=[0.0, 2.0], unit='m')},
+    )
+    assert sc.identical(result, expected)
+
+
+def test_apply_selection_with_units():
+    selection = sc.array(dims=['index'], values=[1, 1, 1], unit=None, dtype='int32')
+    data = sc.arange('detector_number', 3, unit='K', dtype='float64')
+    result = roi.apply_selection(data, selection=selection)
+    expected = sc.array(dims=['detector_number'], values=[1.0], unit='K') * sc.array(
+        dims=['detector_number'], values=[3.0], dtype='float64'
+    )
+    assert sc.identical(result, expected)
+
+
+def test_apply_selection_non_contiguous_indices():
+    selection = sc.array(dims=['index'], values=[0, 4, 4, 8], unit=None, dtype='int32')
+    data = sc.arange('detector_number', 10, dtype='int32')
+    result = roi.apply_selection(data, selection=selection)
+    assert sc.identical(
+        result,
+        sc.array(dims=['detector_number'], values=[0, 4, 8], dtype='int32')
+        * sc.array(dims=['detector_number'], values=[1, 2, 1], dtype='int32'),
+    )
+
+
+def test_apply_selection_ignores_selection_dim():
+    selection = sc.array(dims=['ignored'], values=[1, 2], dtype='int32')
+    data = sc.arange('detector_number', 5, dtype='int32')
+    result = roi.apply_selection(data, selection=selection)
+    assert sc.identical(
+        result, sc.array(dims=['detector_number'], values=[1, 2], dtype='int32')
+    )
+
+
+def test_apply_selection_fails_with_out_of_bounds_index():
+    selection = sc.array(dims=['index'], values=[10], dtype='int32')
+    data = sc.arange('detector_number', 5, dtype='int32')
+    with pytest.raises(IndexError):
+        roi.apply_selection(data, selection=selection)

--- a/tests/live/roi_test.py
+++ b/tests/live/roi_test.py
@@ -156,8 +156,22 @@ def test_ROIFilter_defaults_to_empty_roi(roi_filter: roi.ROIFilter):
 
 
 def test_ROIFilter_applies_roi(roi_filter: roi.ROIFilter):
-    data = sc.linspace('detector_number', 1.0, 24.0, num=24, unit='counts')
     roi_filter.set_roi_from_intervals(sc.DataGroup(x=(1, 3), y=(2, 4)))
+    data = sc.linspace('detector_number', 1.0, 24.0, num=24, unit='counts')
+    result = roi_filter.apply(data)
+    assert sc.identical(
+        result,
+        sc.array(
+            dims=['detector_number'], values=[13.0, 15.0, 21.0, 23.0], unit='counts'
+        ),
+    )
+
+
+def test_ROIFilter_applies_roi_to_2d_data(roi_filter: roi.ROIFilter):
+    roi_filter.set_roi_from_intervals(sc.DataGroup(x=(1, 3), y=(2, 4)))
+    data = sc.linspace('detector_number', 1.0, 24.0, num=24, unit='counts').fold(
+        dim='detector_number', sizes={'x': 3, 'y': 4, 'z': 2}
+    )
     result = roi_filter.apply(data)
     assert sc.identical(
         result,

--- a/tests/live/roi_test.py
+++ b/tests/live/roi_test.py
@@ -142,9 +142,9 @@ def logical_view():
 
 @pytest.fixture
 def roi_filter(logical_view: raw.LogicalView):
-    return roi.ROIFilter.from_logical_view(
-        sizes={'detector_number': 24}, logical_view=logical_view
-    )
+    indices = sc.ones(sizes={'detector_number': 24}, dtype='int32', unit=None)
+    indices = sc.cumsum(indices, mode='exclusive')
+    return roi.ROIFilter(logical_view(indices))
 
 
 def test_ROIFilter_defaults_to_empty_roi(roi_filter: roi.ROIFilter):

--- a/tests/live/roi_test.py
+++ b/tests/live/roi_test.py
@@ -35,6 +35,16 @@ def test_select_indices_label_based_indexing(binned_indices):
     assert selected.sizes[selected.dim] < binned_indices.bins.size().sum().value
 
 
+def test_select_indices_label_based_indexing_reverse_order(binned_indices):
+    selected = roi.select_indices_in_intervals(
+        intervals=sc.DataGroup(x=(sc.scalar(0.5, unit='m'), sc.scalar(0.3, unit='m'))),
+        indices=binned_indices,
+    )
+    assert selected.dim == 'index'
+    assert selected.sizes[selected.dim] > 0
+    assert selected.sizes[selected.dim] < binned_indices.bins.size().sum().value
+
+
 def test_select_indices_fails_with_invalid_dimension():
     data = sc.data.table_xyz(10)
     with pytest.raises(sc.DimensionError):

--- a/tests/live/roi_test.py
+++ b/tests/live/roi_test.py
@@ -59,7 +59,7 @@ def test_apply_selection_empty_yields_empty_result():
     data = sc.arange('detector_number', 12, dtype='int32')
     result = roi.apply_selection(data, selection=selection)
     assert sc.identical(
-        result, sc.array(dims=['detector_number'], values=[], dtype='int32')
+        result, sc.array(dims=['detector_number'], values=[], dtype='float32')
     )
 
 
@@ -68,7 +68,7 @@ def test_apply_selection_single_value():
     data = sc.arange('detector_number', 5, dtype='int32')
     result = roi.apply_selection(data, selection=selection)
     assert sc.identical(
-        result, sc.array(dims=['detector_number'], values=[3], dtype='int32')
+        result, sc.array(dims=['detector_number'], values=[3], dtype='float32')
     )
 
 
@@ -78,8 +78,19 @@ def test_apply_selection_repeated_indices():
     result = roi.apply_selection(data, selection=selection)
     assert sc.identical(
         result,
-        sc.array(dims=['detector_number'], values=[1, 2], dtype='int32')
+        sc.array(dims=['detector_number'], values=[1, 2], dtype='float32')
         * sc.array(dims=['detector_number'], values=[3, 1], dtype='int32'),
+    )
+
+
+@pytest.mark.parametrize('norm', [2, 3])
+def test_apply_selection_repeated_indices_with_norm(norm):
+    selection = sc.array(dims=['index'], values=[1, 1, 2, 1], unit=None, dtype='int32')
+    data = sc.arange('detector_number', 5, dtype='int32')
+    result = roi.apply_selection(data, selection=selection, norm=norm)
+    assert sc.identical(
+        result,
+        sc.array(dims=[data.dim], values=[1 * 3 / norm, 2 * 1 / norm], dtype='float32'),
     )
 
 
@@ -114,7 +125,7 @@ def test_apply_selection_non_contiguous_indices():
     result = roi.apply_selection(data, selection=selection)
     assert sc.identical(
         result,
-        sc.array(dims=['detector_number'], values=[0, 4, 8], dtype='int32')
+        sc.array(dims=['detector_number'], values=[0, 4, 8], dtype='float32')
         * sc.array(dims=['detector_number'], values=[1, 2, 1], dtype='int32'),
     )
 
@@ -124,7 +135,7 @@ def test_apply_selection_ignores_selection_dim():
     data = sc.arange('detector_number', 5, dtype='int32')
     result = roi.apply_selection(data, selection=selection)
     assert sc.identical(
-        result, sc.array(dims=['detector_number'], values=[1, 2], dtype='int32')
+        result, sc.array(dims=['detector_number'], values=[1, 2], dtype='float32')
     )
 
 


### PR DESCRIPTION
This will be used by Beamlime to make time-of-arrival histograms of counts within an ROI. Currently this only supports axis-aligned rectangle selections.