### PR TITLE
Split interface of `StreamProcessor` into two parts

### DIFF
--- a/src/ess/reduce/streaming.py
+++ b/src/ess/reduce/streaming.py
@@ -4,6 +4,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from copy import deepcopy
 from typing import Any, Generic, TypeVar
 
 import networkx as nx
@@ -29,6 +30,8 @@ def maybe_hist(value: T) -> T:
     :
         Histogram.
     """
+    if not isinstance(value, sc.Variable | sc.DataArray):
+        return value
     return value if value.bins is None else value.hist()
 
 
@@ -90,11 +93,11 @@ class EternalAccumulator(Accumulator[T]):
 
     @property
     def value(self) -> T:
-        return self._value.copy()
+        return deepcopy(self._value)
 
     def _do_push(self, value: T) -> None:
         if self._value is None:
-            self._value = value.copy()
+            self._value = deepcopy(value)
         else:
             self._value += value
 
@@ -146,6 +149,7 @@ class StreamProcessor:
         target_keys: tuple[sciline.typing.Key, ...],
         accumulators: dict[sciline.typing.Key, Accumulator, Callable[..., Accumulator]]
         | tuple[sciline.typing.Key, ...],
+        allow_bypass: bool = False,
     ) -> None:
         """
         Create a stream processor.
@@ -163,6 +167,12 @@ class StreamProcessor:
             passed, :py:class:`EternalAccumulator` is used for all keys. Otherwise, a
             dict mapping keys to accumulator instances can be passed. If a dict value is
             a callable, base_workflow.bind_and_call(value) is used to make an instance.
+        allow_bypass:
+            If True, allow bypassing accumulators for keys that are not in the
+            accumulators dict. This is useful for dynamic keys that are not "terminated"
+            in any accumulator. USE WITH CARE! This will lead to incorrect results
+            unless the values for these keys are valid for all chunks comprised in the
+            final accumulators at the point where :py:meth:`finalize` is called.
         """
         workflow = sciline.Pipeline()
         for key in target_keys:
@@ -201,6 +211,7 @@ class StreamProcessor:
             for key, value in self._accumulators.items()
         }
         self._target_keys = target_keys
+        self._allow_bypass = allow_bypass
 
     def add_chunk(
         self, chunks: dict[sciline.typing.Key, Any]
@@ -209,14 +220,6 @@ class StreamProcessor:
         Legacy interface for accumulating values from chunks and finalizing the result.
 
         It is recommended to use :py:meth:`accumulate` and :py:meth:`finalize` instead.
-
-        Warning
-        -------
-
-        This method automatically bypasses accumulators for keys that are not in the
-        accumulators dict. This is useful for dynamic keys that are not "terminated" in
-        any accumulator. USE WITH CARE! This will lead to incorrect results unless the
-        values for these keys are valid for all chunks comprised in the final result.
 
         Parameters
         ----------
@@ -228,12 +231,10 @@ class StreamProcessor:
         :
             Finalized result.
         """
-        self.accumulate(chunks, allow_bypass=True)
+        self.accumulate(chunks)
         return self.finalize()
 
-    def accumulate(
-        self, chunks: dict[sciline.typing.Key, Any], allow_bypass: bool = False
-    ) -> None:
+    def accumulate(self, chunks: dict[sciline.typing.Key, Any]) -> None:
         """
         Accumulate values from chunks without finalizing the result.
 
@@ -241,19 +242,13 @@ class StreamProcessor:
         ----------
         chunks:
             Chunks to be processed.
-        allow_bypass:
-            If True, allow bypassing accumulators for keys that are not in the
-            accumulators dict. This is useful for dynamic keys that are not "terminated"
-            in any accumulator. USE WITH CARE! This will lead to incorrect results
-            unless the values for these keys are valid for all chunks comprised in the
-            final result.
         """
         for key, value in chunks.items():
             self._process_chunk_workflow[key] = value
             # There can be dynamic keys that do not "terminate" in any accumulator. In
             # that case, we need to make sure they can be and are used when computing
             # the target keys.
-            if allow_bypass:
+            if self._allow_bypass:
                 self._finalize_workflow[key] = value
         to_accumulate = self._process_chunk_workflow.compute(self._accumulators)
         for key, processed in to_accumulate.items():


### PR DESCRIPTION
This change is motivated by an updated understanding of how we want to use `StreamProcessor` in `Beamlime`. In particular, we may want to add chunks "eagerly" (so expensive compute can start) instead of "lazily" (when we want to get an updated result plot). This is to reduce latency and improve throughput.

To avoid performing potentially expensive post-accumulation computation with every added chunk, I split `StreamProcessor.add_chunk` into two methods. I also added an `allow_bypass` flag. This is a useful feature that was "on" by default in the previous implementation, but during discussion with @YooSunYoung we discovered that it can have unintended consequences and is risky when used without care (see also docstring). Is it thus off by default.