### PR TITLE
skip some locking mismatched test on macos and windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     needs: formatting
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-latest', 'windows-latest']
+        os: ['ubuntu-24.04']
         python:
           - version: '${{needs.formatting.outputs.min_python}}'
             tox-env: '${{needs.formatting.outputs.min_tox_env}}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     needs: formatting
     strategy:
       matrix:
-        os: ['ubuntu-24.04']
+        os: ['ubuntu-24.04', 'macos-latest', 'windows-latest']
         python:
           - version: '${{needs.formatting.outputs.min_python}}'
             tox-env: '${{needs.formatting.outputs.min_tox_env}}'

--- a/tests/nexus/nexus_loader_test.py
+++ b/tests/nexus/nexus_loader_test.py
@@ -668,8 +668,8 @@ def test_open_nexus_file_multiple_times(tmp_path: Path, locks: tuple[Any, Any]) 
         pytest.param(
             (True, None),
             marks=pytest.mark.skipif(
-                sys.platform == "darwin",
-                reason="MacOS file locking behaves differently",
+                sys.platform in ("darwin", "win32"),
+                reason="MacOS and Windows file locking behaves differently",
             ),
         ),
         (False, True),
@@ -678,8 +678,8 @@ def test_open_nexus_file_multiple_times(tmp_path: Path, locks: tuple[Any, Any]) 
         pytest.param(
             (None, True),
             marks=pytest.mark.skipif(
-                sys.platform == "darwin",
-                reason="MacOS file locking behaves differently",
+                sys.platform in ("darwin", "win32"),
+                reason="MacOS and Windows file locking behaves differently",
             ),
         ),
         # On a read-only filesystem, this would work:
@@ -689,16 +689,16 @@ def test_open_nexus_file_multiple_times(tmp_path: Path, locks: tuple[Any, Any]) 
         pytest.param(
             (True, NoLockingIfNeeded),
             marks=pytest.mark.skipif(
-                sys.platform == "darwin",
-                reason="MacOS file locking behaves differently",
+                sys.platform in ("darwin", "win32"),
+                reason="MacOS and Windows file locking behaves differently",
             ),
         ),
         # Same as above but with roles reversed:
         pytest.param(
             (NoLockingIfNeeded, True),
             marks=pytest.mark.skipif(
-                sys.platform == "darwin",
-                reason="MacOS file locking behaves differently",
+                sys.platform in ("darwin", "win32"),
+                reason="MacOS and Windows file locking behaves differently",
             ),
         ),
     ],

--- a/tests/nexus/nexus_loader_test.py
+++ b/tests/nexus/nexus_loader_test.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
-
+import sys
 from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
@@ -665,18 +665,42 @@ def test_open_nexus_file_multiple_times(tmp_path: Path, locks: tuple[Any, Any]) 
     "locks",
     [
         (True, False),
-        (True, None),
+        pytest.param(
+            (True, None),
+            marks=pytest.mark.skipif(
+                sys.platform == "darwin",
+                reason="MacOS file locking behaves differently",
+            ),
+        ),
         (False, True),
         (False, None),
-        (None, True),
         (None, False),
+        pytest.param(
+            (None, True),
+            marks=pytest.mark.skipif(
+                sys.platform == "darwin",
+                reason="MacOS file locking behaves differently",
+            ),
+        ),
         # On a read-only filesystem, this would work:
         (NoLockingIfNeeded, False),
         # This could be supported, but it could cause problems because the first
         # user expects the file to be locked.
-        (True, NoLockingIfNeeded),
+        pytest.param(
+            (True, NoLockingIfNeeded),
+            marks=pytest.mark.skipif(
+                sys.platform == "darwin",
+                reason="MacOS file locking behaves differently",
+            ),
+        ),
         # Same as above but with roles reversed:
-        (NoLockingIfNeeded, True),
+        pytest.param(
+            (NoLockingIfNeeded, True),
+            marks=pytest.mark.skipif(
+                sys.platform == "darwin",
+                reason="MacOS file locking behaves differently",
+            ),
+        ),
     ],
 )
 def test_open_nexus_file_with_mismatched_locking(


### PR DESCRIPTION
A quick way to avoid https://github.com/scipp/essreduce/issues/197, I've not dug too deep into differences of file locking implementation on MacOS vs Linux, but it looks like on MacOS the implementation is a bit lax?