### PR TITLE
Raise errors if we are trying to access values outside of the distance and pulse range of the time-of-flight lookup table

### DIFF
--- a/src/ess/reduce/time_of_flight/__init__.py
+++ b/src/ess/reduce/time_of_flight/__init__.py
@@ -6,9 +6,9 @@ Utilities for computing real neutron time-of-flight from chopper settings and
 neutron time-of-arrival at the detectors.
 """
 
+from .eto_to_tof import default_parameters, providers, resample_tof_data
 from .simulation import simulate_beamline
 from .to_events import to_events
-from .toa_to_tof import default_parameters, providers, resample_tof_data
 from .types import (
     DistanceResolution,
     LookupTableRelativeErrorThreshold,

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -335,12 +335,12 @@ class TofInterpolator:
             )
         if ltotal.unit != self._distance_unit:
             raise ValueError(
-                f"ltotal must be in unit: {self._distance_unit}, "
+                f"ltotal must have unit: {self._distance_unit}, "
                 f"but got unit: {ltotal.unit}."
             )
         if event_time_offset.unit != self._time_unit:
             raise ValueError(
-                f"event_time_offset must be in unit: {self._time_unit}, "
+                f"event_time_offset must have unit: {self._time_unit}, "
                 f"but got unit: {event_time_offset.unit}."
             )
         out_dims = event_time_offset.dims

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -330,16 +330,16 @@ class TofInterpolator:
         event_time_offset: sc.Variable,
     ) -> sc.Variable:
         if pulse_index.unit != sc.units.dimensionless:
-            raise ValueError(
+            raise sc.UnitError(
                 f"pulse_index must be dimensionless, but got unit: {pulse_index.unit}."
             )
         if ltotal.unit != self._distance_unit:
-            raise ValueError(
+            raise sc.UnitError(
                 f"ltotal must have unit: {self._distance_unit}, "
                 f"but got unit: {ltotal.unit}."
             )
         if event_time_offset.unit != self._time_unit:
-            raise ValueError(
+            raise sc.UnitError(
                 f"event_time_offset must have unit: {self._time_unit}, "
                 f"but got unit: {event_time_offset.unit}."
             )

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -329,9 +329,10 @@ class TofInterpolator:
         ltotal: sc.Variable,
         event_time_offset: sc.Variable,
     ) -> sc.Variable:
-        if pulse_index.unit != sc.units.dimensionless:
+        if pulse_index.unit not in ("", None):
             raise sc.UnitError(
-                f"pulse_index must be dimensionless, but got unit: {pulse_index.unit}."
+                "pulse_index must have unit dimensionless or None, "
+                f"but got unit: {pulse_index.unit}."
             )
         if ltotal.unit != self._distance_unit:
             raise sc.UnitError(


### PR DESCRIPTION
Errors are now raised if we attempt to compute tof outside of the `distance` and `pulse` range of the lookup table.

We do not raise for the `event_time_offset` range (even though it should all wrap around 71ms) because histogrammed monitors often have binning which can be anything (does not necessarily stop at 71ms).
Raising an error here would be too restrictive, and warnings would add noise to the workflows. 