### PR TITLE
Only make events for one dimension when using resample histogram data

### DIFF
--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -617,7 +617,14 @@ def resample_tof_data(da: TofData) -> ResampledTofData:
         Histogrammed data with the time-of-flight coordinate.
     """
     dim = next(iter(set(da.dims) & {"time_of_flight", "tof"}))
-    events = to_events(da.rename_dims({dim: "tof"}), "event")
+    data = da.rename_dims({dim: "tof"}).drop_coords(
+        [
+            name
+            for name in da.coords
+            if (da.coords[name].dims) and (da.coords.is_edges(name)) and (name != "tof")
+        ]
+    )
+    events = to_events(data, "event")
 
     # Define a new bin width, close to the original bin width.
     # TODO: this could be a workflow parameter

--- a/src/ess/reduce/time_of_flight/to_events.py
+++ b/src/ess/reduce/time_of_flight/to_events.py
@@ -34,7 +34,7 @@ def to_events(
     rng = np.random.default_rng()
     event_coords = {}
     edge_dims = []
-    midp_dims = set()
+    midp_dims = set(da.dims)
     midp_coord_names = []
     # Separate bin-edge and midpoints coords
     for name in da.coords:
@@ -43,9 +43,9 @@ def to_events(
         if is_edges:
             if name in dims:
                 edge_dims.append(name)
+                midp_dims -= {name}
         else:
             midp_coord_names.append(name)
-            midp_dims.update(set(dims))
 
     edge_sizes = {dim: da.sizes[da.coords[dim].dim] for dim in edge_dims}
     for dim in edge_dims:


### PR DESCRIPTION
We remove all bin-edge coords apart from `tof` before sending to `to_events` and resampling the histogrammed data, because without this it wil try to make events for all dimensions with bin edges, which can use a lot of RAM, and is not necessary.