### PR TITLE
Replace slow scipp.concat by scipp.broadcast in detector view setup

### DIFF
--- a/src/ess/reduce/live/raw.py
+++ b/src/ess/reduce/live/raw.py
@@ -380,7 +380,8 @@ class RollingDetectorView(Detector):
             pixel_noise = sc.scalar(0.0, unit='m')
             noise_replica_count = 0
         else:
-            noise_replica_count = 16
+            # Unclear what a good number is, could be made configurable.
+            noise_replica_count = 4
         wf = GenericNeXusWorkflow(run_types=[SampleRun], monitor_types=[])
         wf[RollingDetectorViewWindow] = window
         if projection == 'cylinder_mantle_z':


### PR DESCRIPTION
This used to take several seconds for Loki, affecting Beamlime startup times and test run times. This change cuts the times in half, approximately.

For example, Beamlime tests now run in 22 seconds instead of 31 seconds (on my workstation).

I furthermore reduce the number of noise replicas from 16 to 4. This saves another five seconds. The value will likely need to be configured on a per-instrument based in the future.