### PR TITLE
Fix time-of-flight numba interpolation

### DIFF
--- a/src/ess/reduce/time_of_flight/interpolator_numba.py
+++ b/src/ess/reduce/time_of_flight/interpolator_numba.py
@@ -43,13 +43,16 @@ def interpolate(
     if not (len(xp) == len(yp) == len(zp) == len(out)):
         raise ValueError("Interpolator: all input arrays must have the same size.")
 
+    nx = len(x)
+    ny = len(y)
+    nz = len(z)
     npoints = len(xp)
     xmin = x[0]
-    xmax = x[-1]
+    xmax = x[nx - 1]
     ymin = y[0]
-    ymax = y[-1]
+    ymax = y[ny - 1]
     zmin = z[0]
-    zmax = z[-1]
+    zmax = z[nz - 1]
     dx = x[1] - xmin
     dy = y[1] - ymin
     dz = z[1] - zmin
@@ -75,14 +78,14 @@ def interpolate(
             out[i] = fill_value
 
         else:
-            ix = int((xx - xmin) * one_over_dx)
-            iy = int((yy - ymin) * one_over_dy)
-            iz = int((zz - zmin) * one_over_dz)
+            ix = nx - 2 if xx == xmax else int((xx - xmin) * one_over_dx)
+            iy = ny - 2 if yy == ymax else int((yy - ymin) * one_over_dy)
+            iz = nz - 2 if zz == zmax else int((zz - zmin) * one_over_dz)
 
-            y2 = y[iy + 1]
-            y1 = y[iy]
-            x2 = x[ix + 1]
             x1 = x[ix]
+            x2 = x[ix + 1]
+            y1 = y[iy]
+            y2 = y[iy + 1]
             z1 = z[iz]
             z2 = z[iz + 1]
 

--- a/tests/time_of_flight/interpolator_test.py
+++ b/tests/time_of_flight/interpolator_test.py
@@ -81,11 +81,17 @@ def test_numba_and_scipy_interpolators_yield_same_results_with_values_on_edges()
 
     rng = np.random.default_rng(seed=42)
     npoints = 2
+
     times = np.array([0.0, 71.0])
     distances = rng.uniform(39, 71, npoints)
     pulse_indices = rng.uniform(-1, 2, npoints)
-
     numba_result = numba_interp(times, distances, pulse_indices)
     scipy_result = scipy_interp(times, distances, pulse_indices)
+    assert np.allclose(numba_result, scipy_result, equal_nan=True)
 
+    times = rng.uniform(0, 71, npoints)
+    distances = np.array([40.0, 70.0])
+    pulse_indices = rng.uniform(-1, 2, npoints)
+    numba_result = numba_interp(times, distances, pulse_indices)
+    scipy_result = scipy_interp(times, distances, pulse_indices)
     assert np.allclose(numba_result, scipy_result, equal_nan=True)

--- a/tests/time_of_flight/interpolator_test.py
+++ b/tests/time_of_flight/interpolator_test.py
@@ -74,3 +74,18 @@ def test_numba_and_scipy_interpolators_yield_same_results_with_out_of_bounds():
     scipy_result = scipy_interp(times, distances, pulse_indices)
 
     assert np.allclose(numba_result, scipy_result, equal_nan=True)
+
+
+def test_numba_and_scipy_interpolators_yield_same_results_with_values_on_edges():
+    numba_interp, scipy_interp = _make_interpolators()
+
+    rng = np.random.default_rng(seed=42)
+    npoints = 2
+    times = np.array([0.0, 71.0])
+    distances = rng.uniform(39, 71, npoints)
+    pulse_indices = rng.uniform(-1, 2, npoints)
+
+    numba_result = numba_interp(times, distances, pulse_indices)
+    scipy_result = scipy_interp(times, distances, pulse_indices)
+
+    assert np.allclose(numba_result, scipy_result, equal_nan=True)


### PR DESCRIPTION
There was an out-of-bounds issue when a value is exactly on the right edge of the table.
This value is introduced manually when data is histogrammed so that we can rebin the data exactly where the table wraps around.