### PR TITLE
Time-of-flight: remove pulse dimension in lookup table

### DIFF
--- a/docs/user-guide/tof/dream.ipynb
+++ b/docs/user-guide/tof/dream.ipynb
@@ -402,10 +402,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = workflow.compute(time_of_flight.TimeOfFlightLookupTable).squeeze()\n",
+    "table = workflow.compute(time_of_flight.TimeOfFlightLookupTable)\n",
     "\n",
     "# Overlay mean on the figure above\n",
     "table[\"distance\", 13].plot(ax=fig2.ax, color=\"C1\", ls=\"-\", marker=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c06b3e6-9d38-4ce5-9b1e-55283b8eec4c",
+   "metadata": {},
+   "source": [
+    "The full table covers a range of distances, and looks like"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd779e2b-7a69-47f8-a7a2-ad4fa2f3fccc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table.plot()"
    ]
   },
   {
@@ -717,7 +735,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = workflow.compute(time_of_flight.TimeOfFlightLookupTable).squeeze()\n",
+    "table = workflow.compute(time_of_flight.TimeOfFlightLookupTable)\n",
     "table.plot() / (sc.stddevs(table) / sc.values(table)).plot(norm=\"log\")"
    ]
   },
@@ -743,7 +761,7 @@
    "source": [
     "workflow[time_of_flight.LookupTableRelativeErrorThreshold] = 0.01\n",
     "\n",
-    "workflow.compute(time_of_flight.TimeOfFlightLookupTable).squeeze().plot()"
+    "workflow.compute(time_of_flight.TimeOfFlightLookupTable).plot()"
    ]
   },
   {

--- a/docs/user-guide/tof/dream.ipynb
+++ b/docs/user-guide/tof/dream.ipynb
@@ -410,7 +410,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c06b3e6-9d38-4ce5-9b1e-55283b8eec4c",
+   "id": "27",
    "metadata": {},
    "source": [
     "The full table covers a range of distances, and looks like"
@@ -419,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd779e2b-7a69-47f8-a7a2-ad4fa2f3fccc",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,7 +429,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "27",
+   "id": "29",
    "metadata": {},
    "source": [
     "### Computing a time-of-flight coordinate\n",
@@ -440,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,7 +450,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "31",
    "metadata": {},
    "source": [
     "Histogramming the data for a plot should show a profile with 6 bumps that correspond to the frames:"
@@ -459,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +468,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Converting to wavelength\n",
@@ -479,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +499,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "35",
    "metadata": {},
    "source": [
     "### Comparing to the ground truth\n",
@@ -511,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "37",
    "metadata": {},
    "source": [
     "## Multiple detector pixels\n",
@@ -544,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +562,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "39",
    "metadata": {},
    "source": [
     "Our raw data has now a `detector_number` dimension of length 2.\n",
@@ -573,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,7 +588,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "41",
    "metadata": {},
    "source": [
     "Computing time-of-flight is done in the same way as above.\n",
@@ -598,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +632,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "43",
    "metadata": {},
    "source": [
     "## Handling time overlap between subframes\n",
@@ -652,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,7 +683,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "45",
    "metadata": {},
    "source": [
     "We can now see that there is no longer a gap between the two frames at the center of each pulse (green region).\n",
@@ -695,7 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -714,7 +714,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "47",
    "metadata": {},
    "source": [
     "The data in the lookup table contains both the mean time-of-flight for each distance and time-of-arrival bin,\n",
@@ -731,7 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -741,7 +741,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "49",
    "metadata": {},
    "source": [
     "The workflow has a parameter which is used to mask out regions where the standard deviation is above a certain threshold.\n",
@@ -755,7 +755,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -766,7 +766,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "51",
    "metadata": {},
    "source": [
     "We can now see that the central region is masked out.\n",
@@ -781,7 +781,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/user-guide/tof/frame-unwrapping.ipynb
+++ b/docs/user-guide/tof/frame-unwrapping.ipynb
@@ -420,7 +420,7 @@
    "source": [
     "table = workflow.compute(time_of_flight.TimeOfFlightLookupTable)\n",
     "\n",
-    "table[\"pulse\", 0].plot(title=\"Pulse-0\") + table[\"pulse\", 1].plot(title=\"Pulse-1\")"
+    "table.plot()"
    ]
   },
   {

--- a/src/ess/reduce/time_of_flight/interpolator_numba.py
+++ b/src/ess/reduce/time_of_flight/interpolator_numba.py
@@ -8,16 +8,14 @@ from numba import njit, prange
 def interpolate(
     x: np.ndarray,
     y: np.ndarray,
-    z: np.ndarray,
     values: np.ndarray,
     xp: np.ndarray,
     yp: np.ndarray,
-    zp: np.ndarray,
     fill_value: float,
     out: np.ndarray,
 ):
     """
-    Linear interpolation of data on a 3D regular grid.
+    Linear interpolation of data on a 2D regular grid.
 
     Parameters
     ----------
@@ -25,95 +23,77 @@ def interpolate(
         1D array of grid edges along the x-axis. They must be linspaced.
     y:
         1D array of grid edges along the y-axis. They must be linspaced.
-    z:
-        1D array of grid edges along the z-axis. They must be linspaced.
     values:
-        3D array of values on the grid. The shape must be (nz, ny, nx).
+        2D array of values on the grid. The shape must be (ny, nx).
     xp:
         1D array of x-coordinates where to interpolate (size N).
     yp:
         1D array of y-coordinates where to interpolate (size N).
-    zp:
-        1D array of z-coordinates where to interpolate (size N).
     fill_value:
         Value to use for points outside of the grid.
     out:
         1D array where the interpolated values will be stored (size N).
     """
-    if not (len(xp) == len(yp) == len(zp) == len(out)):
+    if not (len(xp) == len(yp) == len(out)):
         raise ValueError("Interpolator: all input arrays must have the same size.")
 
     nx = len(x)
     ny = len(y)
-    nz = len(z)
     npoints = len(xp)
     xmin = x[0]
     xmax = x[nx - 1]
     ymin = y[0]
     ymax = y[ny - 1]
-    zmin = z[0]
-    zmax = z[nz - 1]
     dx = x[1] - xmin
     dy = y[1] - ymin
-    dz = z[1] - zmin
 
     one_over_dx = 1.0 / dx
     one_over_dy = 1.0 / dy
-    one_over_dz = 1.0 / dz
-    norm = one_over_dx * one_over_dy * one_over_dz
+    norm = one_over_dx * one_over_dy
 
     for i in prange(npoints):
         xx = xp[i]
         yy = yp[i]
-        zz = zp[i]
 
-        if (
-            (xx < xmin)
-            or (xx > xmax)
-            or (yy < ymin)
-            or (yy > ymax)
-            or (zz < zmin)
-            or (zz > zmax)
-        ):
+        if (xx < xmin) or (xx > xmax) or (yy < ymin) or (yy > ymax):
             out[i] = fill_value
 
         else:
             ix = nx - 2 if xx == xmax else int((xx - xmin) * one_over_dx)
             iy = ny - 2 if yy == ymax else int((yy - ymin) * one_over_dy)
-            iz = nz - 2 if zz == zmax else int((zz - zmin) * one_over_dz)
 
             x1 = x[ix]
             x2 = x[ix + 1]
             y1 = y[iy]
             y2 = y[iy + 1]
-            z1 = z[iz]
-            z2 = z[iz + 1]
 
-            a111 = values[iz, iy, ix]
-            a211 = values[iz, iy, ix + 1]
-            a121 = values[iz, iy + 1, ix]
-            a221 = values[iz, iy + 1, ix + 1]
-            a112 = values[iz + 1, iy, ix]
-            a212 = values[iz + 1, iy, ix + 1]
-            a122 = values[iz + 1, iy + 1, ix]
-            a222 = values[iz + 1, iy + 1, ix + 1]
+            a11 = values[iy, ix]
+            a21 = values[iy, ix + 1]
+            a12 = values[iy + 1, ix]
+            a22 = values[iy + 1, ix + 1]
 
             x2mxx = x2 - xx
             xxmx1 = xx - x1
-            y2myy = y2 - yy
-            yymy1 = yy - y1
+
             out[i] = (
-                (z2 - zz)
-                * (
-                    y2myy * (x2mxx * a111 + xxmx1 * a211)
-                    + yymy1 * (x2mxx * a121 + xxmx1 * a221)
-                )
-                + (zz - z1)
-                * (
-                    y2myy * (x2mxx * a112 + xxmx1 * a212)
-                    + yymy1 * (x2mxx * a122 + xxmx1 * a222)
-                )
+                (y2 - yy) * (x2mxx * a11 + xxmx1 * a21)
+                + (yy - y1) * (x2mxx * a12 + xxmx1 * a22)
             ) * norm
+
+            # y2myy = y2 - yy
+            # yymy1 = yy - y1
+            # out[i] = (
+            #     (z2 - zz)
+            #     * (
+            #         y2myy * (x2mxx * a111 + xxmx1 * a211)
+            #         + yymy1 * (x2mxx * a121 + xxmx1 * a221)
+            #     )
+            #     + (zz - z1)
+            #     * (
+            #         y2myy * (x2mxx * a112 + xxmx1 * a212)
+            #         + yymy1 * (x2mxx * a122 + xxmx1 * a222)
+            #     )
+            # ) * norm
 
 
 class Interpolator:
@@ -121,12 +101,11 @@ class Interpolator:
         self,
         time_edges: np.ndarray,
         distance_edges: np.ndarray,
-        pulse_edges: np.ndarray,
         values: np.ndarray,
         fill_value: float = np.nan,
     ):
         """
-        Interpolator for 3D regular grid data (Numba implementation).
+        Interpolator for 2D regular grid data (Numba implementation).
 
         Parameters
         ----------
@@ -134,31 +113,24 @@ class Interpolator:
             1D array of time edges.
         distance_edges:
             1D array of distance edges.
-        pulse_edges:
-            1D array of pulse edges.
         values:
-            3D array of values on the grid. The shape must be (nz, ny, nx).
+            2D array of values on the grid. The shape must be (ny, nx).
         fill_value:
             Value to use for points outside of the grid.
         """
         self.time_edges = time_edges
         self.distance_edges = distance_edges
-        self.pulse_edges = pulse_edges
         self.values = values
         self.fill_value = fill_value
 
-    def __call__(
-        self, times: np.ndarray, distances: np.ndarray, pulse_indices: np.ndarray
-    ) -> np.ndarray:
+    def __call__(self, times: np.ndarray, distances: np.ndarray) -> np.ndarray:
         out = np.empty_like(times)
         interpolate(
             x=self.time_edges,
             y=self.distance_edges,
-            z=self.pulse_edges,
             values=self.values,
             xp=times,
             yp=distances,
-            zp=pulse_indices,
             fill_value=self.fill_value,
             out=out,
         )

--- a/src/ess/reduce/time_of_flight/interpolator_numba.py
+++ b/src/ess/reduce/time_of_flight/interpolator_numba.py
@@ -20,9 +20,9 @@ def interpolate(
     Parameters
     ----------
     x:
-        1D array of grid edges along the x-axis. They must be linspaced.
+        1D array of grid edges along the x-axis (size nx). They must be linspaced.
     y:
-        1D array of grid edges along the y-axis. They must be linspaced.
+        1D array of grid edges along the y-axis (size ny). They must be linspaced.
     values:
         2D array of values on the grid. The shape must be (ny, nx).
     xp:
@@ -79,21 +79,6 @@ def interpolate(
                 (y2 - yy) * (x2mxx * a11 + xxmx1 * a21)
                 + (yy - y1) * (x2mxx * a12 + xxmx1 * a22)
             ) * norm
-
-            # y2myy = y2 - yy
-            # yymy1 = yy - y1
-            # out[i] = (
-            #     (z2 - zz)
-            #     * (
-            #         y2myy * (x2mxx * a111 + xxmx1 * a211)
-            #         + yymy1 * (x2mxx * a121 + xxmx1 * a221)
-            #     )
-            #     + (zz - z1)
-            #     * (
-            #         y2myy * (x2mxx * a112 + xxmx1 * a212)
-            #         + yymy1 * (x2mxx * a122 + xxmx1 * a222)
-            #     )
-            # ) * norm
 
 
 class Interpolator:

--- a/src/ess/reduce/time_of_flight/interpolator_scipy.py
+++ b/src/ess/reduce/time_of_flight/interpolator_scipy.py
@@ -21,11 +21,11 @@ class Interpolator:
         Parameters
         ----------
         time_edges:
-            1D array of time edges (length nt).
+            1D array of time edges (length N_time).
         distance_edges:
-            1D array of distance edges (length nd).
+            1D array of distance edges (length N_dist).
         values:
-            2D array of values on the grid. The shape must be (nd, nt).
+            2D array of values on the grid. The shape must be (N_dist, N_time).
         method:
             Method of interpolation. Default is "linear".
         bounds_error:

--- a/src/ess/reduce/time_of_flight/interpolator_scipy.py
+++ b/src/ess/reduce/time_of_flight/interpolator_scipy.py
@@ -9,7 +9,6 @@ class Interpolator:
         self,
         time_edges: np.ndarray,
         distance_edges: np.ndarray,
-        pulse_edges: np.ndarray,
         values: np.ndarray,
         method: str = "linear",
         bounds_error: bool = False,
@@ -17,18 +16,16 @@ class Interpolator:
         **kwargs,
     ):
         """
-        Interpolator for 3D regular grid data (SciPy implementation).
+        Interpolator for 2D regular grid data (SciPy implementation).
 
         Parameters
         ----------
         time_edges:
-            1D array of time edges.
+            1D array of time edges (length nt).
         distance_edges:
-            1D array of distance edges.
-        pulse_edges:
-            1D array of pulse edges.
+            1D array of distance edges (length nd).
         values:
-            3D array of values on the grid. The shape must be (nz, ny, nx).
+            2D array of values on the grid. The shape must be (nd, nt).
         method:
             Method of interpolation. Default is "linear".
         bounds_error:
@@ -43,7 +40,6 @@ class Interpolator:
 
         self._interp = RegularGridInterpolator(
             (
-                pulse_edges,
                 distance_edges,
                 time_edges,
             ),
@@ -54,7 +50,5 @@ class Interpolator:
             **kwargs,
         )
 
-    def __call__(
-        self, times: np.ndarray, distances: np.ndarray, pulse_indices: np.ndarray
-    ) -> np.ndarray:
-        return self._interp((pulse_indices, distances, times))
+    def __call__(self, times: np.ndarray, distances: np.ndarray) -> np.ndarray:
+        return self._interp((distances, times))

--- a/tests/time_of_flight/interpolator_test.py
+++ b/tests/time_of_flight/interpolator_test.py
@@ -11,36 +11,29 @@ from ess.reduce.time_of_flight.interpolator_scipy import (
 )
 
 
-def _f(x, y, z):
+def _f(x, y):
     """
     Function to interpolate, copied from Scipy docs. See
     https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html
     """
 
-    return 2 * x**3 + 3 * y**2 - z
+    return 2 * x**3 + 3 * y**2
 
 
 def _make_interpolators():
     time_edges = np.linspace(0, 71, 101)
     distance_edges = np.linspace(40, 70, 201)
-    pulse_edges = np.linspace(-0.5, 1.5, 5)
-    time_g, distance_g, pulse_g = np.meshgrid(
-        time_edges, distance_edges, pulse_edges, indexing='ij', sparse=True
+    time_g, distance_g = np.meshgrid(
+        time_edges, distance_edges, indexing='ij', sparse=True
     )
-    values = _f(time_g, distance_g, pulse_g).T
+    values = _f(time_g, distance_g).T
 
     numba_interp = InterpolatorNumba(
-        time_edges=time_edges,
-        distance_edges=distance_edges,
-        pulse_edges=pulse_edges,
-        values=values,
+        time_edges=time_edges, distance_edges=distance_edges, values=values
     )
 
     scipy_interp = InterpolatorScipy(
-        time_edges=time_edges,
-        distance_edges=distance_edges,
-        pulse_edges=pulse_edges,
-        values=values,
+        time_edges=time_edges, distance_edges=distance_edges, values=values
     )
     return numba_interp, scipy_interp
 
@@ -52,10 +45,9 @@ def test_numba_and_scipy_interpolators_yield_same_results():
     npoints = 1000
     times = rng.uniform(0, 71, npoints)
     distances = rng.uniform(40, 70, npoints)
-    pulse_indices = rng.uniform(-0.5, 1.5, npoints)
 
-    numba_result = numba_interp(times, distances, pulse_indices)
-    scipy_result = scipy_interp(times, distances, pulse_indices)
+    numba_result = numba_interp(times, distances)
+    scipy_result = scipy_interp(times, distances)
 
     # Do not use equal_nan because there should be no NaNs here
     assert np.allclose(numba_result, scipy_result)
@@ -68,10 +60,9 @@ def test_numba_and_scipy_interpolators_yield_same_results_with_out_of_bounds():
     npoints = 1000
     times = rng.uniform(-1, 72, npoints)
     distances = rng.uniform(39, 71, npoints)
-    pulse_indices = rng.uniform(-1, 2, npoints)
 
-    numba_result = numba_interp(times, distances, pulse_indices)
-    scipy_result = scipy_interp(times, distances, pulse_indices)
+    numba_result = numba_interp(times, distances)
+    scipy_result = scipy_interp(times, distances)
 
     assert np.allclose(numba_result, scipy_result, equal_nan=True)
 
@@ -84,14 +75,12 @@ def test_numba_and_scipy_interpolators_yield_same_results_with_values_on_edges()
 
     times = np.array([0.0, 71.0])
     distances = rng.uniform(39, 71, npoints)
-    pulse_indices = rng.uniform(-1, 2, npoints)
-    numba_result = numba_interp(times, distances, pulse_indices)
-    scipy_result = scipy_interp(times, distances, pulse_indices)
+    numba_result = numba_interp(times, distances)
+    scipy_result = scipy_interp(times, distances)
     assert np.allclose(numba_result, scipy_result, equal_nan=True)
 
     times = rng.uniform(0, 71, npoints)
     distances = np.array([40.0, 70.0])
-    pulse_indices = rng.uniform(-1, 2, npoints)
-    numba_result = numba_interp(times, distances, pulse_indices)
-    scipy_result = scipy_interp(times, distances, pulse_indices)
+    numba_result = numba_interp(times, distances)
+    scipy_result = scipy_interp(times, distances)
     assert np.allclose(numba_result, scipy_result, equal_nan=True)


### PR DESCRIPTION
Instead of making a 3D lookup table with a `pulse` in the case of pulse skipping, we just make a table which spans the `frame_period` instead of the `pulse_period`.
We now send `event_time_offset + pulse_period * pulse_index` as the x coordinates to the interpolator.

This has simplified quite a number of things in the implementation.

Fixes #229 

TODO: I still need to re-run the benchmarks to see if this increased performance (hopefully it did).