### PR TITLE
Time-of-flight interpolator optmizations

### DIFF
--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -311,7 +311,8 @@ class TofInterpolator:
         self,
         ltotal: sc.Variable,
         event_time_offset: sc.Variable,
-        pulse_offset: sc.Variable | None = None,
+        pulse_period: sc.Variable,
+        pulse_index: sc.Variable | None = None,
     ) -> sc.Variable:
         if ltotal.unit != self._distance_unit:
             raise sc.UnitError(
@@ -332,7 +333,8 @@ class TofInterpolator:
             values=self._interpolator(
                 times=event_time_offset,
                 distances=ltotal,
-                pulse_offset=pulse_offset.values if pulse_offset is not None else None,
+                pulse_index=pulse_index.values if pulse_index is not None else None,
+                pulse_period=pulse_period.value,
             ),
             unit=self._time_unit,
         )
@@ -366,7 +368,11 @@ def _time_of_flight_data_histogram(
     interp = TofInterpolator(lookup, distance_unit=ltotal.unit, time_unit=eto_unit)
 
     # Compute time-of-flight of the bin edges using the interpolator
-    tofs = interp(ltotal=ltotal.broadcast(sizes=etos.sizes), event_time_offset=etos)
+    tofs = interp(
+        ltotal=ltotal.broadcast(sizes=etos.sizes),
+        event_time_offset=etos,
+        pulse_period=pulse_period,
+    )
 
     return rebinned.assign_coords(tof=tofs)
 
@@ -425,13 +431,13 @@ def _guess_pulse_stride_offset(
         values=event_time_offset.values[inds],
         unit=event_time_offset.unit,
     )
-    pulse_period = pulse_period.to(unit=etos.unit)
     for i in range(pulse_stride):
         pulse_inds = (pulse_index + i) % pulse_stride
         tofs[i] = interp(
             ltotal=ltotal,
             event_time_offset=etos,
-            pulse_offset=pulse_inds * pulse_period,
+            pulse_index=pulse_inds,
+            pulse_period=pulse_period,
         )
     # Find the entry in the list with the least number of nan values
     return sorted(tofs, key=lambda x: sc.isnan(tofs[x]).sum())[0]
@@ -455,7 +461,9 @@ def _time_of_flight_data_events(
     ltotal = sc.bins_like(etos, ltotal).bins.constituents["data"]
     etos = etos.bins.constituents["data"]
 
-    pulse_offset = None
+    pulse_index = None
+    pulse_period = pulse_period.to(unit=eto_unit)
+
     if pulse_stride > 1:
         # Compute a pulse index for every event: it is the index of the pulse within a
         # frame period. The index ranges from zero to pulse_stride - 1.
@@ -498,10 +506,14 @@ def _time_of_flight_data_events(
             )
         pulse_index += pulse_stride_offset
         pulse_index %= pulse_stride
-        pulse_offset = pulse_index * pulse_period.to(unit=eto_unit)
 
     # Compute time-of-flight for all neutrons using the interpolator
-    tofs = interp(ltotal=ltotal, event_time_offset=etos, pulse_offset=pulse_offset)
+    tofs = interp(
+        ltotal=ltotal,
+        event_time_offset=etos,
+        pulse_index=pulse_index,
+        pulse_period=pulse_period,
+    )
 
     parts = da.bins.constituents
     parts["data"] = tofs

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -330,7 +330,9 @@ class TofInterpolator:
         return sc.array(
             dims=out_dims,
             values=self._interpolator(
-                times=event_time_offset, distances=ltotal, pulse_offset=pulse_offset
+                times=event_time_offset,
+                distances=ltotal,
+                pulse_offset=pulse_offset.values if pulse_offset is not None else None,
             ),
             unit=self._time_unit,
         )

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -453,14 +453,10 @@ def _time_of_flight_data_events(
     ltotal = sc.bins_like(etos, ltotal).bins.constituents["data"]
     etos = etos.bins.constituents["data"]
 
-    # Compute a pulse index for every event: it is the index of the pulse within a
-    # frame period. When there is no pulse skipping, those are all zero. When there is
-    # pulse skipping, the index ranges from zero to pulse_stride - 1.
-    # if pulse_stride == 1:
-    #     pulse_index = sc.zeros(sizes=etos.sizes)
-    # else:
     pulse_offset = None
     if pulse_stride > 1:
+        # Compute a pulse index for every event: it is the index of the pulse within a
+        # frame period. The index ranges from zero to pulse_stride - 1.
         etz_unit = 'ns'
         etz = (
             da.bins.coords["event_time_zero"]
@@ -503,11 +499,7 @@ def _time_of_flight_data_events(
         pulse_offset = pulse_index * pulse_period.to(unit=eto_unit)
 
     # Compute time-of-flight for all neutrons using the interpolator
-    tofs = interp(
-        ltotal=ltotal,
-        event_time_offset=etos,  # + pulse_index * pulse_period.to(unit=eto_unit),
-        pulse_offset=pulse_offset,
-    )
+    tofs = interp(ltotal=ltotal, event_time_offset=etos, pulse_offset=pulse_offset)
 
     parts = da.bins.constituents
     parts["data"] = tofs

--- a/src/ess/reduce/time_of_flight/interpolator_numba.py
+++ b/src/ess/reduce/time_of_flight/interpolator_numba.py
@@ -11,84 +11,7 @@ def interpolate(
     values: np.ndarray,
     xp: np.ndarray,
     yp: np.ndarray,
-    fill_value: float,
-    out: np.ndarray,
-):
-    """
-    Linear interpolation of data on a 2D regular grid.
-
-    Parameters
-    ----------
-    x:
-        1D array of grid edges along the x-axis (size nx). They must be linspaced.
-    y:
-        1D array of grid edges along the y-axis (size ny). They must be linspaced.
-    values:
-        2D array of values on the grid. The shape must be (ny, nx).
-    xp:
-        1D array of x-coordinates where to interpolate (size N).
-    yp:
-        1D array of y-coordinates where to interpolate (size N).
-    fill_value:
-        Value to use for points outside of the grid.
-    out:
-        1D array where the interpolated values will be stored (size N).
-    """
-    if not (len(xp) == len(yp) == len(out)):
-        raise ValueError("Interpolator: all input arrays must have the same size.")
-
-    nx = len(x)
-    ny = len(y)
-    npoints = len(xp)
-    xmin = x[0]
-    xmax = x[nx - 1]
-    ymin = y[0]
-    ymax = y[ny - 1]
-    dx = x[1] - xmin
-    dy = y[1] - ymin
-
-    one_over_dx = 1.0 / dx
-    one_over_dy = 1.0 / dy
-    norm = one_over_dx * one_over_dy
-
-    for i in prange(npoints):
-        xx = xp[i]
-        yy = yp[i]
-
-        if (xx < xmin) or (xx > xmax) or (yy < ymin) or (yy > ymax):
-            out[i] = fill_value
-
-        else:
-            ix = nx - 2 if xx == xmax else int((xx - xmin) * one_over_dx)
-            iy = ny - 2 if yy == ymax else int((yy - ymin) * one_over_dy)
-
-            x1 = x[ix]
-            x2 = x[ix + 1]
-            y1 = y[iy]
-            y2 = y[iy + 1]
-
-            a11 = values[iy, ix]
-            a21 = values[iy, ix + 1]
-            a12 = values[iy + 1, ix]
-            a22 = values[iy + 1, ix + 1]
-
-            x2mxx = x2 - xx
-            xxmx1 = xx - x1
-
-            out[i] = (
-                (y2 - yy) * (x2mxx * a11 + xxmx1 * a21)
-                + (yy - y1) * (x2mxx * a12 + xxmx1 * a22)
-            ) * norm
-
-
-@njit(boundscheck=False, cache=True, fastmath=False, parallel=True)
-def interpolate_with_offset(
-    x: np.ndarray,
-    y: np.ndarray,
-    values: np.ndarray,
-    xp: np.ndarray,
-    yp: np.ndarray,
-    offset: np.ndarray,
+    offset: np.ndarray | None,
     fill_value: float,
     out: np.ndarray,
 ):
@@ -114,7 +37,7 @@ def interpolate_with_offset(
     out:
         1D array where the interpolated values will be stored (size N).
     """
-    if not (len(xp) == len(yp) == len(offset) == len(out)):
+    if not (len(xp) == len(yp) == len(out)):
         raise ValueError("Interpolator: all input arrays must have the same size.")
 
     nx = len(x)
@@ -132,7 +55,7 @@ def interpolate_with_offset(
     norm = one_over_dx * one_over_dy
 
     for i in prange(npoints):
-        xx = xp[i] + offset[i]
+        xx = xp[i] + (offset[i] if offset is not None else 0.0)
         yy = yp[i]
 
         if (xx < xmin) or (xx > xmax) or (yy < ymin) or (yy > ymax):
@@ -195,25 +118,14 @@ class Interpolator:
         pulse_offset: np.ndarray | None = None,
     ) -> np.ndarray:
         out = np.empty_like(times)
-        if pulse_offset is None:
-            interpolate(
-                x=self.time_edges,
-                y=self.distance_edges,
-                values=self.values,
-                xp=times,
-                yp=distances,
-                fill_value=self.fill_value,
-                out=out,
-            )
-        else:
-            interpolate_with_offset(
-                x=self.time_edges,
-                y=self.distance_edges,
-                values=self.values,
-                xp=times,
-                yp=distances,
-                offset=pulse_offset,
-                fill_value=self.fill_value,
-                out=out,
-            )
+        interpolate(
+            x=self.time_edges,
+            y=self.distance_edges,
+            values=self.values,
+            xp=times,
+            yp=distances,
+            offset=pulse_offset,
+            fill_value=self.fill_value,
+            out=out,
+        )
         return out

--- a/src/ess/reduce/time_of_flight/interpolator_numba.py
+++ b/src/ess/reduce/time_of_flight/interpolator_numba.py
@@ -81,6 +81,86 @@ def interpolate(
             ) * norm
 
 
+@njit(boundscheck=False, cache=True, fastmath=False, parallel=True)
+def interpolate_with_offset(
+    x: np.ndarray,
+    y: np.ndarray,
+    values: np.ndarray,
+    xp: np.ndarray,
+    yp: np.ndarray,
+    offset: np.ndarray,
+    fill_value: float,
+    out: np.ndarray,
+):
+    """
+    Linear interpolation of data on a 2D regular grid.
+
+    Parameters
+    ----------
+    x:
+        1D array of grid edges along the x-axis (size nx). They must be linspaced.
+    y:
+        1D array of grid edges along the y-axis (size ny). They must be linspaced.
+    values:
+        2D array of values on the grid. The shape must be (ny, nx).
+    xp:
+        1D array of x-coordinates where to interpolate (size N).
+    yp:
+        1D array of y-coordinates where to interpolate (size N).
+    offset:
+        1D array of offsets to apply to the x-coordinates (size N).
+    fill_value:
+        Value to use for points outside of the grid.
+    out:
+        1D array where the interpolated values will be stored (size N).
+    """
+    if not (len(xp) == len(yp) == len(offset) == len(out)):
+        raise ValueError("Interpolator: all input arrays must have the same size.")
+
+    nx = len(x)
+    ny = len(y)
+    npoints = len(xp)
+    xmin = x[0]
+    xmax = x[nx - 1]
+    ymin = y[0]
+    ymax = y[ny - 1]
+    dx = x[1] - xmin
+    dy = y[1] - ymin
+
+    one_over_dx = 1.0 / dx
+    one_over_dy = 1.0 / dy
+    norm = one_over_dx * one_over_dy
+
+    for i in prange(npoints):
+        xx = xp[i] + offset[i]
+        yy = yp[i]
+
+        if (xx < xmin) or (xx > xmax) or (yy < ymin) or (yy > ymax):
+            out[i] = fill_value
+
+        else:
+            ix = nx - 2 if xx == xmax else int((xx - xmin) * one_over_dx)
+            iy = ny - 2 if yy == ymax else int((yy - ymin) * one_over_dy)
+
+            x1 = x[ix]
+            x2 = x[ix + 1]
+            y1 = y[iy]
+            y2 = y[iy + 1]
+
+            a11 = values[iy, ix]
+            a21 = values[iy, ix + 1]
+            a12 = values[iy + 1, ix]
+            a22 = values[iy + 1, ix + 1]
+
+            x2mxx = x2 - xx
+            xxmx1 = xx - x1
+
+            out[i] = (
+                (y2 - yy) * (x2mxx * a11 + xxmx1 * a21)
+                + (yy - y1) * (x2mxx * a12 + xxmx1 * a22)
+            ) * norm
+
+
 class Interpolator:
     def __init__(
         self,
@@ -108,15 +188,29 @@ class Interpolator:
         self.values = values
         self.fill_value = fill_value
 
-    def __call__(self, times: np.ndarray, distances: np.ndarray) -> np.ndarray:
+    def __call__(
+        self, times: np.ndarray, distances: np.ndarray, pulse_offset: np.ndarray | None
+    ) -> np.ndarray:
         out = np.empty_like(times)
-        interpolate(
-            x=self.time_edges,
-            y=self.distance_edges,
-            values=self.values,
-            xp=times,
-            yp=distances,
-            fill_value=self.fill_value,
-            out=out,
-        )
+        if pulse_offset is None:
+            interpolate(
+                x=self.time_edges,
+                y=self.distance_edges,
+                values=self.values,
+                xp=times,
+                yp=distances,
+                fill_value=self.fill_value,
+                out=out,
+            )
+        else:
+            interpolate_with_offset(
+                x=self.time_edges,
+                y=self.distance_edges,
+                values=self.values,
+                xp=times,
+                yp=distances,
+                offset=pulse_offset,
+                fill_value=self.fill_value,
+                out=out,
+            )
         return out

--- a/src/ess/reduce/time_of_flight/interpolator_numba.py
+++ b/src/ess/reduce/time_of_flight/interpolator_numba.py
@@ -189,7 +189,10 @@ class Interpolator:
         self.fill_value = fill_value
 
     def __call__(
-        self, times: np.ndarray, distances: np.ndarray, pulse_offset: np.ndarray | None
+        self,
+        times: np.ndarray,
+        distances: np.ndarray,
+        pulse_offset: np.ndarray | None = None,
     ) -> np.ndarray:
         out = np.empty_like(times)
         if pulse_offset is None:

--- a/src/ess/reduce/time_of_flight/interpolator_numba.py
+++ b/src/ess/reduce/time_of_flight/interpolator_numba.py
@@ -11,7 +11,8 @@ def interpolate(
     values: np.ndarray,
     xp: np.ndarray,
     yp: np.ndarray,
-    offset: np.ndarray | None,
+    xoffset: np.ndarray | None,
+    deltax: float,
     fill_value: float,
     out: np.ndarray,
 ):
@@ -30,8 +31,10 @@ def interpolate(
         1D array of x-coordinates where to interpolate (size N).
     yp:
         1D array of y-coordinates where to interpolate (size N).
-    offset:
-        1D array of offsets to apply to the x-coordinates (size N).
+    xoffset:
+        1D array of integer offsets to apply to the x-coordinates (size N).
+    deltax:
+        Multiplier to apply to the integer offsets (i.e. the step size).
     fill_value:
         Value to use for points outside of the grid.
     out:
@@ -55,7 +58,7 @@ def interpolate(
     norm = one_over_dx * one_over_dy
 
     for i in prange(npoints):
-        xx = xp[i] + (offset[i] if offset is not None else 0.0)
+        xx = xp[i] + (xoffset[i] * deltax if xoffset is not None else 0.0)
         yy = yp[i]
 
         if (xx < xmin) or (xx > xmax) or (yy < ymin) or (yy > ymax):
@@ -115,7 +118,8 @@ class Interpolator:
         self,
         times: np.ndarray,
         distances: np.ndarray,
-        pulse_offset: np.ndarray | None = None,
+        pulse_period: float = 0.0,
+        pulse_index: np.ndarray | None = None,
     ) -> np.ndarray:
         out = np.empty_like(times)
         interpolate(
@@ -124,7 +128,8 @@ class Interpolator:
             values=self.values,
             xp=times,
             yp=distances,
-            offset=pulse_offset,
+            xoffset=pulse_index,
+            deltax=pulse_period,
             fill_value=self.fill_value,
             out=out,
         )

--- a/src/ess/reduce/time_of_flight/interpolator_scipy.py
+++ b/src/ess/reduce/time_of_flight/interpolator_scipy.py
@@ -50,5 +50,9 @@ class Interpolator:
             **kwargs,
         )
 
-    def __call__(self, times: np.ndarray, distances: np.ndarray) -> np.ndarray:
+    def __call__(
+        self, times: np.ndarray, distances: np.ndarray, pulse_offset: np.ndarray | None
+    ) -> np.ndarray:
+        if pulse_offset is not None:
+            times = times + pulse_offset
         return self._interp((distances, times))

--- a/src/ess/reduce/time_of_flight/interpolator_scipy.py
+++ b/src/ess/reduce/time_of_flight/interpolator_scipy.py
@@ -51,7 +51,10 @@ class Interpolator:
         )
 
     def __call__(
-        self, times: np.ndarray, distances: np.ndarray, pulse_offset: np.ndarray | None
+        self,
+        times: np.ndarray,
+        distances: np.ndarray,
+        pulse_offset: np.ndarray | None = None,
     ) -> np.ndarray:
         if pulse_offset is not None:
             times = times + pulse_offset

--- a/src/ess/reduce/time_of_flight/interpolator_scipy.py
+++ b/src/ess/reduce/time_of_flight/interpolator_scipy.py
@@ -39,10 +39,7 @@ class Interpolator:
         from scipy.interpolate import RegularGridInterpolator
 
         self._interp = RegularGridInterpolator(
-            (
-                distance_edges,
-                time_edges,
-            ),
+            (distance_edges, time_edges),
             values,
             method=method,
             bounds_error=bounds_error,
@@ -54,8 +51,9 @@ class Interpolator:
         self,
         times: np.ndarray,
         distances: np.ndarray,
-        pulse_offset: np.ndarray | None = None,
+        pulse_period: float = 0.0,
+        pulse_index: np.ndarray | None = None,
     ) -> np.ndarray:
-        if pulse_offset is not None:
-            times = times + pulse_offset
+        if pulse_index is not None:
+            times = times + (pulse_index * pulse_period)
         return self._interp((distances, times))

--- a/tests/time_of_flight/interpolator_test.py
+++ b/tests/time_of_flight/interpolator_test.py
@@ -53,6 +53,21 @@ def test_numba_and_scipy_interpolators_yield_same_results():
     assert np.allclose(numba_result, scipy_result)
 
 
+def test_numba_and_scipy_interpolators_yield_same_results_with_pulse_offset():
+    numba_interp, scipy_interp = _make_interpolators()
+
+    rng = np.random.default_rng(seed=42)
+    npoints = 1000
+    times = rng.uniform(0, 71, npoints)
+    distances = rng.uniform(40, 70, npoints)
+    offsets = rng.uniform(0, 2, npoints)
+
+    numba_result = numba_interp(times, distances, offsets)
+    scipy_result = scipy_interp(times, distances, offsets)
+
+    assert np.allclose(numba_result, scipy_result, equal_nan=True)
+
+
 def test_numba_and_scipy_interpolators_yield_same_results_with_out_of_bounds():
     numba_interp, scipy_interp = _make_interpolators()
 

--- a/tests/time_of_flight/interpolator_test.py
+++ b/tests/time_of_flight/interpolator_test.py
@@ -61,9 +61,10 @@ def test_numba_and_scipy_interpolators_yield_same_results_with_pulse_offset():
     times = rng.uniform(0, 71, npoints)
     distances = rng.uniform(40, 70, npoints)
     offsets = rng.uniform(0, 2, npoints)
+    period = 1.0
 
-    numba_result = numba_interp(times, distances, offsets)
-    scipy_result = scipy_interp(times, distances, offsets)
+    numba_result = numba_interp(times, distances, period, offsets)
+    scipy_result = scipy_interp(times, distances, period, offsets)
 
     assert np.allclose(numba_result, scipy_result, equal_nan=True)
 


### PR DESCRIPTION
Avoid some large allocations when not needed.

The 2D implementation was actually slower than the old one because of allocations.
We now got the time for ~72M events down from 0.83s to 0.33s.
The old 3D implementation is at 0.43s.

~Unfortunately, I had to duplicate code in the numba interpolator.~
~Suggestions for a better alternative welcome.~
Fixed it, you can just use the `None` type in Numba, I wasn't sure you could...