### PR TITLE
Generic tof workflow

### DIFF
--- a/src/ess/reduce/nexus/types.py
+++ b/src/ess/reduce/nexus/types.py
@@ -232,7 +232,7 @@ class CalibratedDetector(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Calibrated data from a detector."""
 
 
-class CalibratedBeamline(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+class CalibratedDetectorBeamline(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Calibrated beamline with detector and other components."""
 
 
@@ -240,6 +240,12 @@ class CalibratedMonitor(
     sciline.Scope[RunType, MonitorType, sc.DataArray], sc.DataArray
 ):
     """Calibrated data from a monitor."""
+
+
+class CalibratedMonitorBeamline(
+    sciline.Scope[RunType, MonitorType, sc.DataArray], sc.DataArray
+):
+    """Calibrated beamline with monitor and other components."""
 
 
 class DetectorData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):

--- a/src/ess/reduce/nexus/workflow.py
+++ b/src/ess/reduce/nexus/workflow.py
@@ -753,30 +753,3 @@ def GenericNeXusWorkflow(
         prune_type_vars(wf, run_types=run_types, monitor_types=monitor_types)
 
     return wf
-
-
-# def _prune_type_vars(
-#     workflow: sciline.Pipeline,
-#     *,
-#     run_types: Iterable[sciline.typing.Key] | None,
-#     monitor_types: Iterable[sciline.typing.Key] | None,
-# ) -> None:
-#     # Remove all nodes that use a run type or monitor types that is
-#     # not listed in the function arguments.
-#     excluded_run_types = _excluded_type_args(RunType, run_types)
-#     excluded_monitor_types = _excluded_type_args(MonitorType, monitor_types)
-#     excluded_types = excluded_run_types | excluded_monitor_types
-
-#     graph = workflow.underlying_graph
-#     to_remove = [
-#         node for node in graph if excluded_types & set(getattr(node, "__args__", set()))
-#     ]
-#     graph.remove_nodes_from(to_remove)
-
-
-# def _excluded_type_args(
-#     type_var: Any, keep: Iterable[sciline.typing.Key] | None
-# ) -> set[sciline.typing.Key]:
-#     if keep is None:
-#         return set()
-#     return set(type_var.__constraints__) - set(keep)

--- a/src/ess/reduce/time_of_flight/__init__.py
+++ b/src/ess/reduce/time_of_flight/__init__.py
@@ -6,42 +6,52 @@ Utilities for computing real neutron time-of-flight from chopper settings and
 neutron time-of-arrival at the detectors.
 """
 
-from .eto_to_tof import default_parameters, providers, resample_tof_data
+from .eto_to_tof import (
+    default_parameters,
+    providers,
+    resample_detector_time_of_flight_data,
+    resample_monitor_time_of_flight_data,
+)
 from .simulation import simulate_beamline
 from .to_events import to_events
 from .types import (
+    DetectorLtotal,
+    DetectorTofData,
     DistanceResolution,
     LookupTableRelativeErrorThreshold,
-    Ltotal,
     LtotalRange,
+    MonitorLtotal,
+    MonitorTofData,
     PulsePeriod,
     PulseStride,
     PulseStrideOffset,
-    RawData,
-    ResampledTofData,
+    ResampledDetectorTofData,
+    ResampledMonitorTofData,
     SimulationResults,
     TimeOfFlightLookupTable,
     TimeResolution,
-    TofData,
 )
 
 __all__ = [
+    "DetectorLtotal",
+    "DetectorTofData",
     "DistanceResolution",
     "LookupTableRelativeErrorThreshold",
-    "Ltotal",
     "LtotalRange",
+    "MonitorLtotal",
+    "MonitorTofData",
     "PulsePeriod",
     "PulseStride",
     "PulseStrideOffset",
-    "RawData",
-    "ResampledTofData",
+    "ResampledDetectorTofData",
+    "ResampledMonitorTofData",
     "SimulationResults",
     "TimeOfFlightLookupTable",
     "TimeResolution",
-    "TofData",
     "default_parameters",
     "providers",
-    "resample_tof_data",
+    "resample_detector_time_of_flight_data",
+    "resample_monitor_time_of_flight_data",
     "simulate_beamline",
     "to_events",
 ]

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -15,6 +15,11 @@ import scippneutron as scn
 from scipp._scipp.core import _bins_no_validate
 from scippneutron._utils import elem_unit
 
+try:
+    from .interpolator_numba import Interpolator as InterpolatorImpl
+except ImportError:
+    from .interpolator_scipy import Interpolator as InterpolatorImpl
+
 from ..nexus.types import (
     CalibratedDetectorBeamline,
     CalibratedMonitorBeamline,
@@ -23,12 +28,6 @@ from ..nexus.types import (
     MonitorType,
     RunType,
 )
-
-# try:
-#     from .interpolator_numba import Interpolator as InterpolatorImpl
-# except ImportError:
-#     from .interpolator_scipy import Interpolator as InterpolatorImpl
-from .interpolator_scipy import Interpolator as InterpolatorImpl
 from .to_events import to_events
 from .types import (
     DetectorLtotal,

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -34,20 +34,17 @@ from .types import (
     DetectorTofData,
     DistanceResolution,
     LookupTableRelativeErrorThreshold,
-    # Ltotal,
     LtotalRange,
     MonitorLtotal,
     MonitorTofData,
     PulsePeriod,
     PulseStride,
     PulseStrideOffset,
-    # RawData,
     ResampledDetectorTofData,
     ResampledMonitorTofData,
     SimulationResults,
     TimeOfFlightLookupTable,
     TimeResolution,
-    # TofData,
 )
 
 

--- a/src/ess/reduce/time_of_flight/types.py
+++ b/src/ess/reduce/time_of_flight/types.py
@@ -4,12 +4,15 @@
 from dataclasses import dataclass
 from typing import NewType
 
+import sciline as sl
 import scipp as sc
 
-Ltotal = NewType("Ltotal", sc.Variable)
-"""
-Total length of the flight path from the source to the detector.
-"""
+from ..nexus.types import MonitorType, RunType
+
+# Ltotal = NewType("Ltotal", sc.Variable)
+# """
+# Total length of the flight path from the source to the detector.
+# """
 
 
 @dataclass
@@ -107,30 +110,63 @@ When pulse-skipping, the offset of the first pulse in the stride. This is typica
 zero but can be a small integer < pulse_stride. If None, a guess is made.
 """
 
-RawData = NewType("RawData", sc.DataArray)
-"""
-Raw detector data loaded from a NeXus file, e.g., NXdetector containing NXevent_data.
-"""
+# RawData = NewType("RawData", sc.DataArray)
+# """
+# Raw detector data loaded from a NeXus file, e.g., NXdetector containing NXevent_data.
+# """
 
-TofData = NewType("TofData", sc.DataArray)
-"""
-Detector data with time-of-flight coordinate.
-"""
 
-ResampledTofData = NewType("ResampledTofData", sc.DataArray)
-"""
-Histogrammed detector data with time-of-flight coordinate, that has been resampled.
+class DetectorLtotal(sl.Scope[RunType, sc.Variable], sc.Variable):
+    """Total path length of neutrons from source to detector (L1 + L2)."""
 
-Histogrammed data that has been converted to `tof` will typically have
-unsorted bin edges (due to either wrapping of `time_of_flight` or wavelength
-overlap between subframes).
-We thus resample the data to ensure that the bin edges are sorted.
-It makes use of the ``to_events`` helper which generates a number of events in each
-bin with a uniform distribution. The new events are then histogrammed using a set of
-sorted bin edges to yield a new histogram with sorted bin edges.
 
-WARNING:
-This function is highly experimental, has limitations and should be used with
-caution. It is a workaround to the issue that rebinning data with unsorted bin
-edges is not supported in scipp.
-"""
+class MonitorLtotal(sl.Scope[RunType, MonitorType, sc.Variable], sc.Variable):
+    """Total path length of neutrons from source to monitor."""
+
+
+class DetectorTofData(sl.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Detector data with time-of-flight coordinate."""
+
+
+class MonitorTofData(sl.Scope[RunType, MonitorType, sc.DataArray], sc.DataArray):
+    """Monitor data with time-of-flight coordinate."""
+
+
+class ResampledDetectorTofData(sl.Scope[RunType, sc.DataArray], sc.DataArray):
+    """
+    Histogrammed detector data with time-of-flight coordinate, that has been resampled.
+
+    Histogrammed data that has been converted to `tof` will typically have
+    unsorted bin edges (due to either wrapping of `time_of_flight` or wavelength
+    overlap between subframes).
+    We thus resample the data to ensure that the bin edges are sorted.
+    It makes use of the ``to_events`` helper which generates a number of events in each
+    bin with a uniform distribution. The new events are then histogrammed using a set of
+    sorted bin edges to yield a new histogram with sorted bin edges.
+
+    WARNING:
+    This function is highly experimental, has limitations and should be used with
+    caution. It is a workaround to the issue that rebinning data with unsorted bin
+    edges is not supported in scipp.
+    """
+
+
+class ResampledMonitorTofData(
+    sl.Scope[RunType, MonitorType, sc.DataArray], sc.DataArray
+):
+    """
+    Histogrammed monitor data with time-of-flight coordinate, that has been resampled.
+
+    Histogrammed data that has been converted to `tof` will typically have
+    unsorted bin edges (due to either wrapping of `time_of_flight` or wavelength
+    overlap between subframes).
+    We thus resample the data to ensure that the bin edges are sorted.
+    It makes use of the ``to_events`` helper which generates a number of events in each
+    bin with a uniform distribution. The new events are then histogrammed using a set of
+    sorted bin edges to yield a new histogram with sorted bin edges.
+
+    WARNING:
+    This function is highly experimental, has limitations and should be used with
+    caution. It is a workaround to the issue that rebinning data with unsorted bin
+    edges is not supported in scipp.
+    """

--- a/src/ess/reduce/time_of_flight/types.py
+++ b/src/ess/reduce/time_of_flight/types.py
@@ -9,11 +9,6 @@ import scipp as sc
 
 from ..nexus.types import MonitorType, RunType
 
-# Ltotal = NewType("Ltotal", sc.Variable)
-# """
-# Total length of the flight path from the source to the detector.
-# """
-
 
 @dataclass
 class SimulationResults:
@@ -109,11 +104,6 @@ PulseStrideOffset = NewType("PulseStrideOffset", int | None)
 When pulse-skipping, the offset of the first pulse in the stride. This is typically
 zero but can be a small integer < pulse_stride. If None, a guess is made.
 """
-
-# RawData = NewType("RawData", sc.DataArray)
-# """
-# Raw detector data loaded from a NeXus file, e.g., NXdetector containing NXevent_data.
-# """
 
 
 class DetectorLtotal(sl.Scope[RunType, sc.Variable], sc.Variable):

--- a/src/ess/reduce/time_of_flight/workflow.py
+++ b/src/ess/reduce/time_of_flight/workflow.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+from collections.abc import Iterable
+
+import sciline
+
+from ..nexus import GenericNeXusWorkflow
+from .eto_to_tof import default_parameters, providers
+
+
+def GenericTofWorkflow(
+    *,
+    run_types: Iterable[sciline.typing.Key] | None = None,
+    monitor_types: Iterable[sciline.typing.Key] | None = None,
+) -> sciline.Pipeline:
+    """ """
+    wf = GenericNeXusWorkflow()
+
+    for provider in providers():
+        wf.insert(provider)
+
+    for key, value in default_parameters().items():
+        wf[key] = value
+
+    if run_types is not None or monitor_types is not None:
+        from ..utils import prune_type_vars
+
+        prune_type_vars(wf, run_types=run_types, monitor_types=monitor_types)
+
+    return wf

--- a/src/ess/reduce/utils.py
+++ b/src/ess/reduce/utils.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+from collections.abc import Iterable
+from typing import Any
+
+import sciline
+
+from .nexus.types import MonitorType, RunType
+
+
+def prune_type_vars(
+    workflow: sciline.Pipeline,
+    *,
+    run_types: Iterable[sciline.typing.Key] | None,
+    monitor_types: Iterable[sciline.typing.Key] | None,
+) -> None:
+    # Remove all nodes that use a run type or monitor types that is
+    # not listed in the function arguments.
+    excluded_run_types = excluded_type_args(RunType, run_types)
+    excluded_monitor_types = excluded_type_args(MonitorType, monitor_types)
+    excluded_types = excluded_run_types | excluded_monitor_types
+
+    graph = workflow.underlying_graph
+    to_remove = [
+        node for node in graph if excluded_types & set(getattr(node, "__args__", set()))
+    ]
+    graph.remove_nodes_from(to_remove)
+
+
+def excluded_type_args(
+    type_var: Any, keep: Iterable[sciline.typing.Key] | None
+) -> set[sciline.typing.Key]:
+    if keep is None:
+        return set()
+    return set(type_var.__constraints__) - set(keep)

--- a/tests/time_of_flight/wfm_test.py
+++ b/tests/time_of_flight/wfm_test.py
@@ -9,6 +9,7 @@ from scippneutron.conversion.graph.beamline import beamline as beamline_graph
 from scippneutron.conversion.graph.tof import elastic as elastic_graph
 
 from ess.reduce import time_of_flight
+from ess.reduce.nexus.types import DetectorData, SampleRun
 from ess.reduce.time_of_flight import fakes
 
 sl = pytest.importorskip("sciline")
@@ -167,12 +168,12 @@ def test_dream_wfm(simulation_dream_choppers, ltotal, time_offset_unit, distance
         time_of_flight.providers(), params=time_of_flight.default_parameters()
     )
 
-    pl[time_of_flight.RawData] = raw
-    pl[time_of_flight.Ltotal] = ltotal
+    pl[DetectorData[SampleRun]] = raw
+    pl[time_of_flight.DetectorLtotal[SampleRun]] = ltotal
     pl[time_of_flight.SimulationResults] = simulation_dream_choppers
     pl[time_of_flight.LtotalRange] = ltotal.min(), ltotal.max()
 
-    tofs = pl.compute(time_of_flight.TofData)
+    tofs = pl.compute(time_of_flight.DetectorTofData[SampleRun])
 
     # Convert to wavelength
     graph = {**beamline_graph(scatter=False), **elastic_graph("tof")}
@@ -252,13 +253,13 @@ def test_dream_wfm_with_subframe_time_overlap(
         time_of_flight.providers(), params=time_of_flight.default_parameters()
     )
 
-    pl[time_of_flight.RawData] = raw
+    pl[DetectorData[SampleRun]] = raw
     pl[time_of_flight.SimulationResults] = simulation_dream_choppers_time_overlap
-    pl[time_of_flight.Ltotal] = ltotal
+    pl[time_of_flight.DetectorLtotal[SampleRun]] = ltotal
     pl[time_of_flight.LtotalRange] = ltotal.min(), ltotal.max()
     pl[time_of_flight.LookupTableRelativeErrorThreshold] = 0.01
 
-    tofs = pl.compute(time_of_flight.TofData)
+    tofs = pl.compute(time_of_flight.DetectorTofData[SampleRun])
 
     # Convert to wavelength
     graph = {**beamline_graph(scatter=False), **elastic_graph("tof")}
@@ -437,12 +438,12 @@ def test_v20_compute_wavelengths_from_wfm(
         time_of_flight.providers(), params=time_of_flight.default_parameters()
     )
 
-    pl[time_of_flight.RawData] = raw
+    pl[DetectorData[SampleRun]] = raw
     pl[time_of_flight.SimulationResults] = simulation_v20_choppers
-    pl[time_of_flight.Ltotal] = ltotal
+    pl[time_of_flight.DetectorLtotal[SampleRun]] = ltotal
     pl[time_of_flight.LtotalRange] = ltotal.min(), ltotal.max()
 
-    tofs = pl.compute(time_of_flight.TofData)
+    tofs = pl.compute(time_of_flight.DetectorTofData[SampleRun])
 
     # Convert to wavelength
     graph = {**beamline_graph(scatter=False), **elastic_graph("tof")}


### PR DESCRIPTION
We build on top of the `GenericNexusWorkflow` to add the computation of time-of-flight for the neutron data.

See https://github.com/scipp/essimaging/pull/81 for an example of how this is used in instrument reduction workflows.

The graph is the following. Important thing to note is that Ltotal is extracted from the calibrated beamline, not from the detector data, meaning that it is not extracted/computed again every time new streaming events come in.
![tbl-tof-wf](https://github.com/user-attachments/assets/ec049149-ddfd-4532-b233-a282cc5a864b)
