### PR TITLE
Remove analyzers from nexus workflow

### DIFF
--- a/src/ess/reduce/nexus/types.py
+++ b/src/ess/reduce/nexus/types.py
@@ -341,10 +341,3 @@ class Choppers(
     sc.DataGroup[sc.DataGroup[Any]],
 ):
     """All choppers in a NeXus file."""
-
-
-class Analyzers(
-    sciline.Scope[RunType, sc.DataGroup[sc.DataGroup[Any]]],
-    sc.DataGroup[sc.DataGroup[Any]],
-):
-    """All analyzers in a NeXus file."""

--- a/src/ess/reduce/nexus/workflow.py
+++ b/src/ess/reduce/nexus/workflow.py
@@ -19,7 +19,6 @@ from ..utils import prune_type_vars
 from . import _nexus_loader as nexus
 from .types import (
     AllNeXusComponents,
-    Analyzers,
     Beamline,
     CalibratedBeamline,
     CalibratedDetector,
@@ -525,13 +524,6 @@ def parse_disk_choppers(
     )
 
 
-def parse_analyzers(
-    analyzers: AllNeXusComponents[snx.NXcrystal, RunType],
-) -> Analyzers[RunType]:
-    """Convert the NeXus representation of an analyzer to ours."""
-    return Analyzers[RunType](analyzers.apply(nexus.compute_component_position))
-
-
 def _drop(
     children: dict[str, snx.Field | snx.Group], classes: tuple[snx.NXobject, ...]
 ) -> dict[str, snx.Field | snx.Group]:
@@ -628,7 +620,6 @@ _common_providers = (
     nx_class_for_source,
     nx_class_for_sample,
     nx_class_for_disk_chopper,
-    nx_class_for_crystal,
 )
 
 _monitor_providers = (
@@ -646,8 +637,6 @@ _detector_providers = (
 )
 
 _chopper_providers = (parse_disk_choppers,)
-
-_analyzer_providers = (parse_analyzers,)
 
 _metadata_providers = (
     load_beamline_metadata_from_nexus,
@@ -711,7 +700,6 @@ def GenericNeXusWorkflow(
             *_monitor_providers,
             *_detector_providers,
             *_chopper_providers,
-            *_analyzer_providers,
             *_metadata_providers,
         )
     )

--- a/tests/nexus/nexus_loader_test.py
+++ b/tests/nexus/nexus_loader_test.py
@@ -107,27 +107,6 @@ def _choppers_data() -> sc.DataGroup[sc.DataGroup[Any]]:
     )
 
 
-def _analyzers_data() -> sc.DataGroup[sc.DataGroup[Any]]:
-    return sc.DataGroup[sc.DataGroup[Any]](
-        {
-            'analyzer_B': sc.DataGroup[Any](
-                {
-                    'd_spacing': sc.scalar(3.355, unit='angstrom'),
-                    'usage': 'Bragg',
-                    'nexus_component_name': 'analyzer_B',
-                }
-            ),
-            'analyzer_A': sc.DataGroup[Any](
-                {
-                    'd_spacing': sc.scalar(3.104, unit='angstrom'),
-                    'usage': 'Bragg',
-                    'nexus_component_name': 'analyzer_A',
-                }
-            ),
-        }
-    )
-
-
 def _write_transformation(group: snx.Group, offset: sc.Variable) -> None:
     group.create_field('depends_on', sc.scalar('transformations/t1'))
     transformations = group.create_class('transformations', snx.NXtransformations)
@@ -183,11 +162,6 @@ def _write_nexus_data(store: Path | BytesIO) -> None:
             chop.create_field('slit_edges', chopper['slit_edges'])
             chop.create_field('slit_height', chopper['slit_height'])
             chop.create_field('slits', chopper['slits'])
-
-        for name, analyzer in _analyzers_data().items():
-            ana = instrument.create_class(name, snx.NXcrystal)
-            ana.create_field('d_spacing', analyzer['d_spacing'])
-            ana.create_field('usage', analyzer['usage'])
 
 
 @contextmanager
@@ -271,11 +245,6 @@ def expected_sample() -> sc.DataGroup:
 @pytest.fixture
 def expected_choppers() -> sc.DataGroup[sc.DataGroup[Any]]:
     return _choppers_data()
-
-
-@pytest.fixture
-def expected_analyzers() -> sc.DataGroup[sc.DataGroup[Any]]:
-    return _analyzers_data()
 
 
 def test_load_data_loads_expected_event_data(nexus_file, expected_bank12):
@@ -534,16 +503,6 @@ def test_load_disk_choppers(nexus_file, expected_choppers, entry_name):
     )
     choppers = nexus.load_all_components(loc, nx_class=snx.NXdisk_chopper)
     sc.testing.assert_identical(choppers, expected_choppers)
-
-
-@pytest.mark.parametrize('entry_name', [None, nexus.types.NeXusEntryName('entry-001')])
-def test_load_analyzers(nexus_file, expected_analyzers, entry_name):
-    loc = NeXusLocationSpec(
-        filename=nexus_file,
-        entry_name=entry_name,
-    )
-    analyzers = nexus.load_all_components(loc, nx_class=snx.NXcrystal)
-    sc.testing.assert_identical(analyzers, expected_analyzers)
 
 
 def test_extract_detector_data():

--- a/tests/nexus/workflow_test.py
+++ b/tests/nexus/workflow_test.py
@@ -10,7 +10,6 @@ from scipp.testing import assert_identical
 from ess.reduce import data
 from ess.reduce.nexus import compute_component_position, workflow
 from ess.reduce.nexus.types import (
-    Analyzers,
     BackgroundRun,
     Beamline,
     Choppers,
@@ -573,18 +572,6 @@ def test_generic_nexus_workflow_load_choppers() -> None:
     assert chopper['slit_edges'].shape == (2,)
 
 
-def test_generic_nexus_workflow_load_analyzers() -> None:
-    wf = GenericNeXusWorkflow()
-    wf[Filename[SampleRun]] = data.bifrost_simulated_elastic()
-    analyzers = wf.compute(Analyzers[SampleRun])
-
-    assert len(analyzers) == 45
-    analyzer = analyzers['144_channel_2_1_monochromator']
-    assert 'position' in analyzer
-    assert analyzer['d_spacing'].ndim == 0
-    assert analyzer['usage'] == 'Bragg'
-
-
 def test_generic_nexus_workflow_load_beamline_metadata() -> None:
     wf = GenericNeXusWorkflow()
     wf[Filename[SampleRun]] = data.bifrost_simulated_elastic()
@@ -626,8 +613,6 @@ def test_generic_nexus_workflow_includes_only_given_run_and_monitor_types() -> N
     assert MonitorData[BackgroundRun, Monitor3] not in graph
     assert Choppers[SampleRun] in graph
     assert Choppers[BackgroundRun] not in graph
-    assert Analyzers[SampleRun] in graph
-    assert Analyzers[BackgroundRun] not in graph
 
     assert NeXusComponentLocationSpec[Monitor1, SampleRun] in graph
     assert NeXusComponentLocationSpec[Monitor2, SampleRun] not in graph
@@ -664,8 +649,6 @@ def test_generic_nexus_workflow_includes_only_given_run_types() -> None:
     assert MonitorData[SampleRun, Monitor3] not in graph
     assert Choppers[EmptyBeamRun] in graph
     assert Choppers[SampleRun] not in graph
-    assert Analyzers[EmptyBeamRun] in graph
-    assert Analyzers[SampleRun] not in graph
 
     excluded_run_types = set(RunType.__constraints__) - {EmptyBeamRun}
     for node in graph:
@@ -689,8 +672,6 @@ def test_generic_nexus_workflow_includes_only_given_monitor_types() -> None:
     assert MonitorData[BackgroundRun, Monitor3] not in graph
     assert Choppers[SampleRun] in graph
     assert Choppers[BackgroundRun] in graph
-    assert Analyzers[SampleRun] in graph
-    assert Analyzers[BackgroundRun] in graph
 
     excluded_monitor_types = set(MonitorType.__constraints__) - {
         Monitor1,


### PR DESCRIPTION
Analyzers are fairly uncommon at ESS (3 instruments) and as of right now, we don't load them using the mechanism that was removed here. Instead, we have a dedicated implementation for BIFROST. So this should not break anything downstream.