### PR TITLE
Time-of-flight: Add loading lookup table from file

### DIFF
--- a/docs/user-guide/tof/dream.ipynb
+++ b/docs/user-guide/tof/dream.ipynb
@@ -305,7 +305,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wf = time_of_flight.GenericTofWorkflow()\n",
+    "wf = time_of_flight.GenericTofWorkflow(\n",
+    "    tof_lut_provider=time_of_flight.TofLutProvider.TOF\n",
+    ")\n",
     "wf[DetectorData[SampleRun]] = raw_data\n",
     "wf[time_of_flight.DetectorLtotal[SampleRun]] = Ltotal\n",
     "wf[time_of_flight.LtotalRange] = (\n",

--- a/docs/user-guide/tof/frame-unwrapping.ipynb
+++ b/docs/user-guide/tof/frame-unwrapping.ipynb
@@ -159,7 +159,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wf = time_of_flight.GenericTofWorkflow()\n",
+    "wf = time_of_flight.GenericTofWorkflow(\n",
+    "    tof_lut_provider=time_of_flight.TofLutProvider.TOF\n",
+    ")\n",
     "\n",
     "wf[DetectorData[SampleRun]] = nxevent_data\n",
     "wf[time_of_flight.DetectorLtotal[SampleRun]] = nxevent_data.coords[\"Ltotal\"]\n",
@@ -368,7 +370,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wf = time_of_flight.GenericTofWorkflow()\n",
+    "wf = time_of_flight.GenericTofWorkflow(\n",
+    "    tof_lut_provider=time_of_flight.TofLutProvider.TOF\n",
+    ")\n",
     "\n",
     "nxevent_data = results.to_nxevent_data()\n",
     "\n",

--- a/docs/user-guide/tof/wfm.ipynb
+++ b/docs/user-guide/tof/wfm.ipynb
@@ -326,7 +326,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wf = time_of_flight.GenericTofWorkflow()\n",
+    "wf = time_of_flight.GenericTofWorkflow(\n",
+    "    tof_lut_provider=time_of_flight.TofLutProvider.TOF\n",
+    ")\n",
     "wf[DetectorData[SampleRun]] = raw_data\n",
     "wf[time_of_flight.DetectorLtotal[SampleRun]] = Ltotal\n",
     "wf[time_of_flight.LtotalRange] = Ltotal, Ltotal\n",
@@ -353,9 +355,7 @@
    "outputs": [],
    "source": [
     "wf[time_of_flight.SimulationResults] = time_of_flight.simulate_beamline(\n",
-    "    choppers=disk_choppers,\n",
-    "    source_position=source_position,\n",
-    "    neutrons=3_000_000\n",
+    "    choppers=disk_choppers, source_position=source_position, neutrons=3_000_000\n",
     ")"
    ]
   },

--- a/src/ess/reduce/time_of_flight/__init__.py
+++ b/src/ess/reduce/time_of_flight/__init__.py
@@ -29,9 +29,10 @@ from .types import (
     ResampledMonitorTofData,
     SimulationResults,
     TimeOfFlightLookupTable,
+    TimeOfFlightLookupTableFilename,
     TimeResolution,
 )
-from .workflow import GenericTofWorkflow
+from .workflow import GenericTofWorkflow, TofLutProvider
 
 __all__ = [
     "DetectorLtotal",
@@ -49,7 +50,9 @@ __all__ = [
     "ResampledMonitorTofData",
     "SimulationResults",
     "TimeOfFlightLookupTable",
+    "TimeOfFlightLookupTableFilename",
     "TimeResolution",
+    "TofLutProvider",
     "default_parameters",
     "providers",
     "resample_detector_time_of_flight_data",

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -12,7 +12,6 @@ from collections.abc import Callable
 import numpy as np
 import scipp as sc
 import scippneutron as scn
-from scipp._scipp.core import _bins_no_validate
 from scippneutron._utils import elem_unit
 
 try:
@@ -532,7 +531,7 @@ def _time_of_flight_data_events(
 
     parts = da.bins.constituents
     parts["data"] = tofs
-    return da.bins.assign_coords(tof=_bins_no_validate(**parts))
+    return da.bins.assign_coords(tof=sc.bins(**parts, validate_indices=False))
 
 
 def detector_ltotal_from_straight_line_approximation(

--- a/src/ess/reduce/time_of_flight/simulation.py
+++ b/src/ess/reduce/time_of_flight/simulation.py
@@ -3,9 +3,11 @@
 from collections.abc import Mapping
 
 import scipp as sc
+import scippnexus as snx
 from scippneutron.chopper import DiskChopper
 
-from .types import SimulationResults
+from ..nexus.types import Choppers, Position, SampleRun
+from .types import NumberOfSimulatedNeutrons, SimulationResults
 
 
 def simulate_beamline(
@@ -81,4 +83,26 @@ def simulate_beamline(
         wavelength=events.coords["wavelength"],
         weight=events.data,
         distance=furthest_chopper.distance,
+    )
+
+
+def simulate_chopper_cascade_using_tof(
+    choppers: Choppers[SampleRun],
+    neutrons: NumberOfSimulatedNeutrons,
+    source_position: Position[snx.NXsource, SampleRun],
+) -> SimulationResults:
+    """
+    Simulate neutrons traveling through the chopper cascade using the ``tof`` package.
+
+    Parameters
+    ----------
+    choppers:
+        Chopper settings.
+    neutrons:
+        Number of neutrons to simulate.
+    source_position:
+        Position of the source.
+    """
+    return simulate_beamline(
+        choppers=choppers, neutrons=neutrons, source_position=source_position
     )

--- a/src/ess/reduce/time_of_flight/types.py
+++ b/src/ess/reduce/time_of_flight/types.py
@@ -46,6 +46,12 @@ class SimulationResults:
     distance: sc.Variable
 
 
+NumberOfSimulatedNeutrons = NewType("NumberOfSimulatedNeutrons", int)
+"""
+Number of neutrons simulated in the simulation that is used to create the lookup table.
+This is typically a large number, e.g., 1e6 or 1e7.
+"""
+
 LtotalRange = NewType("LtotalRange", tuple[sc.Variable, sc.Variable])
 """
 Range (min, max) of the total length of the flight path from the source to the detector.
@@ -77,6 +83,10 @@ Since the event_time_offset range needs to span exactly one pulse period, the fi
 resolution in the lookup table will be at least the supplied value here, but may be
 smaller if the pulse period is not an integer multiple of the time resolution.
 """
+
+TimeOfFlightLookupTableFilename = NewType("TimeOfFlightLookupTableFilename", str)
+"""Filename of the time-of-flight lookup table."""
+
 
 TimeOfFlightLookupTable = NewType("TimeOfFlightLookupTable", sc.DataArray)
 """

--- a/src/ess/reduce/time_of_flight/workflow.py
+++ b/src/ess/reduce/time_of_flight/workflow.py
@@ -16,7 +16,7 @@ class TofLutProvider(Enum):
     """Provider for the time-of-flight lookup table."""
 
     FILE = auto()  # From file
-    TOF = auto()  # Computed from chopper settings
+    TOF = auto()  # Computed with 'tof' package from chopper settings
     MCSTAS = auto()  # McStas simulation (not implemented yet)
 
 

--- a/src/ess/reduce/workflow.py
+++ b/src/ess/reduce/workflow.py
@@ -53,12 +53,14 @@ def get_typical_outputs(pipeline: Pipeline) -> tuple[Key, ...]:
     if (typical_outputs := getattr(pipeline, "typical_outputs", None)) is None:
         graph = pipeline.underlying_graph
         sink_nodes = [node for node, degree in graph.out_degree if degree == 0]
-        return sorted(_with_pretty_names(sink_nodes))
+        return sorted(_with_pretty_names(sink_nodes), key=lambda x: x[0])
     return _with_pretty_names(typical_outputs)
 
 
 def get_possible_outputs(pipeline: Pipeline) -> tuple[Key, ...]:
-    return sorted(_with_pretty_names(tuple(pipeline.underlying_graph.nodes)))
+    return sorted(
+        _with_pretty_names(tuple(pipeline.underlying_graph.nodes)), key=lambda x: x[0]
+    )
 
 
 def _with_pretty_names(outputs: Sequence[Key]) -> tuple[tuple[str, Key], ...]:

--- a/tests/time_of_flight/workflow_test.py
+++ b/tests/time_of_flight/workflow_test.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+import numpy as np
+import pytest
+import sciline
+import scipp as sc
+import scippnexus as snx
+from scipp.testing import assert_identical
+
+from ess.reduce import time_of_flight
+from ess.reduce.nexus.types import (
+    CalibratedBeamline,
+    Choppers,
+    DetectorData,
+    NeXusData,
+    Position,
+    SampleRun,
+)
+from ess.reduce.time_of_flight import GenericTofWorkflow, TofLutProvider, fakes
+
+sl = pytest.importorskip("sciline")
+
+
+@pytest.fixture
+def calibrated_beamline():
+    return sc.DataArray(
+        data=sc.ones(dims=["detector_number"], shape=[10]),
+        coords={
+            "Ltotal": sc.scalar(80.0, unit="m"),
+            "detector_number": sc.array(
+                dims=["detector_number"], values=np.arange(10), unit=None
+            ),
+        },
+    )
+
+
+@pytest.fixture
+def nexus_data():
+    events = sc.DataArray(
+        data=sc.ones(dims=["event"], shape=[1000]),
+        coords={
+            "event_time_offset": sc.linspace(
+                "event", 0.0, 1000.0 / 14, num=1000, unit="ms"
+            ).to(unit="ns"),
+            "event_id": sc.array(
+                dims=["event"], values=np.arange(1000) % 10, unit=None
+            ),
+        },
+    )
+    return sc.DataArray(
+        sc.bins(
+            begin=sc.array(dims=["pulse"], values=[0], unit=None),
+            data=events,
+            dim="event",
+        )
+    )
+
+
+def test_GenericTofWorkflow_can_compute_tof_lut_without_nexus_file_or_detector_info():
+    wf = GenericTofWorkflow(tof_lut_provider=TofLutProvider.TOF)
+    wf[Choppers[SampleRun]] = fakes.psc_choppers()
+    wf[time_of_flight.types.NumberOfSimulatedNeutrons] = 10_000
+    wf[time_of_flight.types.LtotalRange] = (
+        sc.scalar(0.0, unit="m"),
+        sc.scalar(100.0, unit="m"),
+    )
+    wf[Position[snx.NXsource, SampleRun]] = fakes.source_position()
+    lut = wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    assert isinstance(lut, sc.DataArray)
+
+
+def test_GenericTofWorkflow_with_tof_lut_from_tof_simulation(
+    calibrated_beamline: sc.DataArray, nexus_data: sc.DataArray
+):
+    wf = GenericTofWorkflow(tof_lut_provider=TofLutProvider.TOF)
+    wf[CalibratedBeamline[SampleRun]] = calibrated_beamline
+    wf[NeXusData[snx.NXdetector, SampleRun]] = nexus_data
+
+    # Should be able to compute DetectorData without chopper and simulation params
+    # This contains event_time_offset (time-of-arrival).
+    _ = wf.compute(DetectorData[SampleRun])
+    # LUT and Tof data cannot be computed without chopper and simulation params
+    with pytest.raises(sciline.UnsatisfiedRequirement):
+        _ = wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    with pytest.raises(sciline.UnsatisfiedRequirement):
+        _ = wf.compute(time_of_flight.DetectorTofData[SampleRun])
+
+    wf[Choppers[SampleRun]] = fakes.psc_choppers()
+    wf[time_of_flight.types.NumberOfSimulatedNeutrons] = 10_000
+    wf[time_of_flight.types.LtotalRange] = (
+        sc.scalar(0.0, unit="m"),
+        sc.scalar(100.0, unit="m"),
+    )
+    wf[Position[snx.NXsource, SampleRun]] = fakes.source_position()
+
+    # Should be able to compute DetectorData with chopper and simulation params
+    _ = wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    detector = wf.compute(time_of_flight.DetectorTofData[SampleRun])
+    assert 'tof' in detector.bins.coords
+
+
+def test_GenericTofWorkflow_with_tof_lut_from_mcstas_simulation():
+    with pytest.raises(
+        NotImplementedError, match="McStas simulation not implemented yet"
+    ):
+        GenericTofWorkflow(tof_lut_provider=TofLutProvider.MCSTAS)
+
+
+def test_GenericTofWorkflow_with_tof_lut_from_file(
+    calibrated_beamline: sc.DataArray,
+    nexus_data: sc.DataArray,
+    tmp_path: pytest.TempPathFactory,
+):
+    make_lut_wf = GenericTofWorkflow(tof_lut_provider=TofLutProvider.TOF)
+    make_lut_wf[Choppers[SampleRun]] = fakes.psc_choppers()
+    make_lut_wf[time_of_flight.types.NumberOfSimulatedNeutrons] = 10_000
+    make_lut_wf[time_of_flight.types.LtotalRange] = (
+        sc.scalar(0.0, unit="m"),
+        sc.scalar(100.0, unit="m"),
+    )
+    make_lut_wf[Position[snx.NXsource, SampleRun]] = fakes.source_position()
+    lut = make_lut_wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    lut.save_hdf5(filename=tmp_path / "lut.h5")
+
+    wf = GenericTofWorkflow(tof_lut_provider=TofLutProvider.FILE)
+    wf[CalibratedBeamline[SampleRun]] = calibrated_beamline
+    wf[NeXusData[snx.NXdetector, SampleRun]] = nexus_data
+    wf[time_of_flight.TimeOfFlightLookupTableFilename] = (
+        tmp_path / "lut.h5"
+    ).as_posix()
+
+    loaded_lut = wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    assert_identical(lut, loaded_lut)
+
+    detector = wf.compute(time_of_flight.DetectorTofData[SampleRun])
+    assert 'tof' in detector.bins.coords


### PR DESCRIPTION
`GenericTofWorkflow` will try to load from a file by default. Keyword arg allows for selecting a Tof or McStas simulation (not implemented, but by using an `Enum` adding this should hopefully be possible without breaking changes).