### PR TITLE
Distinguish between raw and parsed choppers

### DIFF
--- a/src/ess/reduce/nexus/types.py
+++ b/src/ess/reduce/nexus/types.py
@@ -8,6 +8,7 @@ import sciline
 import scipp as sc
 import scippnexus as snx
 from scippneutron import metadata as scn_meta
+from scippneutron.chopper import DiskChopper
 
 FilePath = NewType('FilePath', Path)
 """Full path to a NeXus file on disk."""
@@ -293,8 +294,15 @@ class NeXusTransformation(Generic[Component, RunType]):
         return NeXusTransformation(value=transform)
 
 
-class Choppers(
+class RawChoppers(
     sciline.Scope[RunType, sc.DataGroup[sc.DataGroup[Any]]],
     sc.DataGroup[sc.DataGroup[Any]],
 ):
     """All choppers in a NeXus file."""
+
+
+class DiskChoppers(
+    sciline.Scope[RunType, sc.DataGroup[DiskChopper]],
+    sc.DataGroup[DiskChopper],
+):
+    """All disk choppers parsed from a NeXus file."""

--- a/src/ess/reduce/nexus/workflow.py
+++ b/src/ess/reduce/nexus/workflow.py
@@ -23,7 +23,6 @@ from .types import (
     CalibratedBeamline,
     CalibratedDetector,
     CalibratedMonitor,
-    Choppers,
     Component,
     DetectorBankSizes,
     DetectorData,
@@ -46,6 +45,7 @@ from .types import (
     NeXusTransformationChain,
     Position,
     PreopenNeXusFile,
+    RawChoppers,
     RunType,
     SampleRun,
     TimeInterval,
@@ -513,9 +513,18 @@ def assemble_monitor_data(
 
 def parse_disk_choppers(
     choppers: AllNeXusComponents[snx.NXdisk_chopper, RunType],
-) -> Choppers[RunType]:
-    """Convert the NeXus representation of a chopper to ours."""
-    return Choppers[RunType](
+) -> RawChoppers[RunType]:
+    """Convert the NeXus representation of a chopper to ours.
+
+    Returns
+    -------
+    :
+        A nested data group containing the loaded choppers.
+        The elements may be time-dependent arrays that first need to be processed
+        before they can be passed to other functions as
+        :class:`ess.reduce.nexus.types.DiskChoppers`.
+    """
+    return RawChoppers[RunType](
         choppers.apply(
             lambda chopper: extract_chopper_from_nexus(
                 nexus.compute_component_position(chopper)

--- a/src/ess/reduce/time_of_flight/simulation.py
+++ b/src/ess/reduce/time_of_flight/simulation.py
@@ -6,7 +6,7 @@ import scipp as sc
 import scippnexus as snx
 from scippneutron.chopper import DiskChopper
 
-from ..nexus.types import Choppers, Position, SampleRun
+from ..nexus.types import DiskChoppers, Position, SampleRun
 from .types import NumberOfSimulatedNeutrons, SimulationResults
 
 
@@ -87,7 +87,7 @@ def simulate_beamline(
 
 
 def simulate_chopper_cascade_using_tof(
-    choppers: Choppers[SampleRun],
+    choppers: DiskChoppers[SampleRun],
     neutrons: NumberOfSimulatedNeutrons,
     source_position: Position[snx.NXsource, SampleRun],
 ) -> SimulationResults:

--- a/tests/nexus/workflow_test.py
+++ b/tests/nexus/workflow_test.py
@@ -12,7 +12,6 @@ from ess.reduce.nexus import compute_component_position, workflow
 from ess.reduce.nexus.types import (
     BackgroundRun,
     Beamline,
-    Choppers,
     DetectorData,
     EmptyBeamRun,
     Filename,
@@ -26,6 +25,7 @@ from ess.reduce.nexus.types import (
     NeXusName,
     NeXusTransformation,
     PreopenNeXusFile,
+    RawChoppers,
     RunType,
     SampleRun,
     TimeInterval,
@@ -556,7 +556,7 @@ def test_generic_nexus_workflow(preopen: bool) -> None:
 def test_generic_nexus_workflow_load_choppers() -> None:
     wf = GenericNeXusWorkflow(run_types=[SampleRun], monitor_types=[])
     wf[Filename[SampleRun]] = data.bifrost_simulated_elastic()
-    choppers = wf.compute(Choppers[SampleRun])
+    choppers = wf.compute(RawChoppers[SampleRun])
 
     assert choppers.keys() == {
         '005_PulseShapingChopper',
@@ -613,8 +613,8 @@ def test_generic_nexus_workflow_includes_only_given_run_and_monitor_types() -> N
     assert MonitorData[BackgroundRun, FrameMonitor0] not in graph
     assert MonitorData[BackgroundRun, FrameMonitor1] not in graph
     assert MonitorData[BackgroundRun, FrameMonitor2] not in graph
-    assert Choppers[SampleRun] in graph
-    assert Choppers[BackgroundRun] not in graph
+    assert RawChoppers[SampleRun] in graph
+    assert RawChoppers[BackgroundRun] not in graph
 
     assert NeXusComponentLocationSpec[FrameMonitor0, SampleRun] in graph
     assert NeXusComponentLocationSpec[FrameMonitor1, SampleRun] in graph
@@ -655,8 +655,8 @@ def test_generic_nexus_workflow_includes_only_given_run_types() -> None:
     assert MonitorData[SampleRun, FrameMonitor1] not in graph
     assert MonitorData[SampleRun, FrameMonitor2] not in graph
     assert MonitorData[SampleRun, FrameMonitor0] not in graph
-    assert Choppers[EmptyBeamRun] in graph
-    assert Choppers[SampleRun] not in graph
+    assert RawChoppers[EmptyBeamRun] in graph
+    assert RawChoppers[SampleRun] not in graph
 
     excluded_run_types = set(RunType.__constraints__) - {EmptyBeamRun}
     for node in graph:
@@ -681,8 +681,8 @@ def test_generic_nexus_workflow_includes_only_given_monitor_types() -> None:
     assert MonitorData[BackgroundRun, FrameMonitor1] in graph
     assert MonitorData[BackgroundRun, FrameMonitor2] not in graph
     assert MonitorData[BackgroundRun, FrameMonitor0] not in graph
-    assert Choppers[SampleRun] in graph
-    assert Choppers[BackgroundRun] in graph
+    assert RawChoppers[SampleRun] in graph
+    assert RawChoppers[BackgroundRun] in graph
 
     excluded_monitor_types = set(MonitorType.__constraints__) - {
         FrameMonitor1,

--- a/tests/time_of_flight/workflow_test.py
+++ b/tests/time_of_flight/workflow_test.py
@@ -10,8 +10,8 @@ from scipp.testing import assert_identical
 from ess.reduce import time_of_flight
 from ess.reduce.nexus.types import (
     CalibratedBeamline,
-    Choppers,
     DetectorData,
+    DiskChoppers,
     NeXusData,
     Position,
     SampleRun,
@@ -62,7 +62,7 @@ def test_GenericTofWorkflow_can_compute_tof_lut_without_nexus_file_or_detector_i
         run_types=[SampleRun],
         monitor_types=[],
     )
-    wf[Choppers[SampleRun]] = fakes.psc_choppers()
+    wf[DiskChoppers[SampleRun]] = fakes.psc_choppers()
     wf[time_of_flight.types.NumberOfSimulatedNeutrons] = 10_000
     wf[time_of_flight.types.LtotalRange] = (
         sc.scalar(0.0, unit="m"),
@@ -93,7 +93,7 @@ def test_GenericTofWorkflow_with_tof_lut_from_tof_simulation(
     with pytest.raises(sciline.UnsatisfiedRequirement):
         _ = wf.compute(time_of_flight.DetectorTofData[SampleRun])
 
-    wf[Choppers[SampleRun]] = fakes.psc_choppers()
+    wf[DiskChoppers[SampleRun]] = fakes.psc_choppers()
     wf[time_of_flight.types.NumberOfSimulatedNeutrons] = 10_000
     wf[time_of_flight.types.LtotalRange] = (
         sc.scalar(0.0, unit="m"),
@@ -128,7 +128,7 @@ def test_GenericTofWorkflow_with_tof_lut_from_file(
         run_types=[SampleRun],
         monitor_types=[],
     )
-    make_lut_wf[Choppers[SampleRun]] = fakes.psc_choppers()
+    make_lut_wf[DiskChoppers[SampleRun]] = fakes.psc_choppers()
     make_lut_wf[time_of_flight.types.NumberOfSimulatedNeutrons] = 10_000
     make_lut_wf[time_of_flight.types.LtotalRange] = (
         sc.scalar(0.0, unit="m"),


### PR DESCRIPTION
The tof workflow incorrectly assumes that loaded `Choppers` are `DiskChopper` objects. In reality, they are `DataGroup`s. This means that the tof workflow fails at during `compute`. This PR splits the `Choppers` type into two. One for the nested data groups loaded from NeXus and one for processed `DiskChopper` objects. There is no provider to connect the two because that is a complicated process that involves finding plateaus and extracting scalar quantities from the NeXus data. See https://scipp.github.io/scippneutron/user-guide/chopper/processing-nexus-choppers.html

If the data is completely flat, this can be simple. E.g., for the simulated BIFROST data, we can simply do this:
```python
def extract_chopper_plateau(chopper):
    processed = chopper.copy()
    # These are constant in the simulated data.
    processed['rotation_speed'] = processed['rotation_speed'].data.mean()
    processed['phase'] = processed['phase'].data.mean()
    # Guessing here as this is not stored in the file.
    processed['beam_position'] = sc.scalar(0.0, unit='deg')
    return DiskChopper.from_nexus(processed)


def extract_chopper_plateaus(choppers: RawChoppers[RunType]) -> DiskChoppers[RunType]:
    return DiskChoppers[RunType](choppers.apply(extract_chopper_plateau))

workflow.insert(parse_disk_choppers)
```