### PR TITLE
Use `RunType` instead of `SampleRun` for tof lookup table

### DIFF
--- a/docs/user-guide/tof/dream.ipynb
+++ b/docs/user-guide/tof/dream.ipynb
@@ -337,7 +337,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wf[time_of_flight.SimulationResults] = time_of_flight.simulate_beamline(\n",
+    "wf[time_of_flight.SimulationResults[SampleRun]] = time_of_flight.simulate_beamline(\n",
     "    choppers=disk_choppers, source_position=source_position, neutrons=2_000_000\n",
     ")"
    ]
@@ -365,7 +365,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = wf.compute(time_of_flight.SimulationResults)\n",
+    "sim = wf.compute(time_of_flight.SimulationResults[SampleRun])\n",
     "\n",
     "\n",
     "def to_event_time_offset(sim):\n",
@@ -404,7 +404,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable)\n",
+    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])\n",
     "\n",
     "# Overlay mean on the figure above\n",
     "table[\"distance\", 13].plot(ax=fig2.ax, color=\"C1\", ls=\"-\", marker=None)"
@@ -702,13 +702,13 @@
    "outputs": [],
    "source": [
     "# Update workflow\n",
-    "wf[time_of_flight.SimulationResults] = time_of_flight.simulate_beamline(\n",
+    "wf[time_of_flight.SimulationResults[SampleRun]] = time_of_flight.simulate_beamline(\n",
     "    choppers=disk_choppers, source_position=source_position, neutrons=2_000_000\n",
     ")\n",
     "wf[DetectorData[SampleRun]] = ess_beamline.get_monitor(\"detector\")[0]\n",
     "wf[time_of_flight.DetectorLtotal[SampleRun]] = Ltotal\n",
     "\n",
-    "sim = wf.compute(time_of_flight.SimulationResults)\n",
+    "sim = wf.compute(time_of_flight.SimulationResults[SampleRun])\n",
     "\n",
     "events = to_event_time_offset(sim)\n",
     "events.hist(wavelength=300, event_time_offset=300).plot(norm=\"log\")"
@@ -737,7 +737,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable)\n",
+    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])\n",
     "table.plot() / (sc.stddevs(table) / sc.values(table)).plot(norm=\"log\")"
    ]
   },
@@ -763,7 +763,7 @@
    "source": [
     "wf[time_of_flight.LookupTableRelativeErrorThreshold] = 0.01\n",
     "\n",
-    "wf.compute(time_of_flight.TimeOfFlightLookupTable).plot()"
+    "wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun]).plot()"
    ]
   },
   {

--- a/docs/user-guide/tof/frame-unwrapping.ipynb
+++ b/docs/user-guide/tof/frame-unwrapping.ipynb
@@ -168,7 +168,7 @@
     "wf[DetectorData[SampleRun]] = nxevent_data\n",
     "wf[time_of_flight.DetectorLtotal[SampleRun]] = nxevent_data.coords[\"Ltotal\"]\n",
     "wf[time_of_flight.LtotalRange] = detectors[0].distance, detectors[-1].distance\n",
-    "wf[time_of_flight.SimulationResults] = time_of_flight.simulate_beamline(\n",
+    "wf[time_of_flight.SimulationResults[SampleRun]] = time_of_flight.simulate_beamline(\n",
     "    choppers={\n",
     "        \"chopper\": DiskChopper(\n",
     "            frequency=-chopper.frequency,\n",
@@ -227,7 +227,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable)\n",
+    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])\n",
     "table.plot()"
    ]
   },
@@ -384,7 +384,7 @@
     "wf[DetectorData[SampleRun]] = nxevent_data\n",
     "wf[time_of_flight.DetectorLtotal[SampleRun]] = nxevent_data.coords[\"Ltotal\"]\n",
     "wf[time_of_flight.LtotalRange] = detectors[0].distance, detectors[-1].distance\n",
-    "wf[time_of_flight.SimulationResults] = time_of_flight.simulate_beamline(\n",
+    "wf[time_of_flight.SimulationResults[SampleRun]] = time_of_flight.simulate_beamline(\n",
     "    choppers={\n",
     "        ch.name: DiskChopper(\n",
     "            frequency=-ch.frequency,\n",
@@ -422,7 +422,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable)\n",
+    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])\n",
     "\n",
     "table.plot()"
    ]

--- a/docs/user-guide/tof/wfm.ipynb
+++ b/docs/user-guide/tof/wfm.ipynb
@@ -356,7 +356,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wf[time_of_flight.SimulationResults] = time_of_flight.simulate_beamline(\n",
+    "wf[time_of_flight.SimulationResults[SampleRun]] = time_of_flight.simulate_beamline(\n",
     "    choppers=disk_choppers, source_position=source_position, neutrons=3_000_000\n",
     ")"
    ]
@@ -384,7 +384,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = wf.compute(time_of_flight.SimulationResults)\n",
+    "sim = wf.compute(time_of_flight.SimulationResults[SampleRun])\n",
     "# Compute time-of-arrival at the detector\n",
     "tarrival = sim.time_of_arrival + ((Ltotal - sim.distance) / sim.speed).to(unit=\"us\")\n",
     "# Compute time-of-flight at the detector\n",
@@ -416,7 +416,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable)\n",
+    "table = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])\n",
     "\n",
     "# Overlay mean on the figure above\n",
     "table[\"distance\", 1].plot(ax=fig2.ax, color=\"C1\", ls=\"-\", marker=None)\n",

--- a/src/ess/reduce/time_of_flight/eto_to_tof.py
+++ b/src/ess/reduce/time_of_flight/eto_to_tof.py
@@ -143,14 +143,14 @@ def _compute_mean_tof_in_distance_range(
 
 
 def compute_tof_lookup_table(
-    simulation: SimulationResults,
+    simulation: SimulationResults[RunType],
     ltotal_range: LtotalRange,
     distance_resolution: DistanceResolution,
     time_resolution: TimeResolution,
     pulse_period: PulsePeriod,
     pulse_stride: PulseStride,
     error_threshold: LookupTableRelativeErrorThreshold,
-) -> TimeOfFlightLookupTable:
+) -> TimeOfFlightLookupTable[RunType]:
     """
     Compute a lookup table for time-of-flight as a function of distance and
     time-of-arrival.
@@ -300,7 +300,7 @@ def compute_tof_lookup_table(
     # In-place masking for better performance
     _mask_large_uncertainty(table, error_threshold)
 
-    return TimeOfFlightLookupTable(table)
+    return TimeOfFlightLookupTable[RunType](table)
 
 
 class TofInterpolator:
@@ -597,7 +597,7 @@ def _compute_tof_data(
 
 def detector_time_of_flight_data(
     detector_data: DetectorData[RunType],
-    lookup: TimeOfFlightLookupTable,
+    lookup: TimeOfFlightLookupTable[RunType],
     ltotal: DetectorLtotal[RunType],
     pulse_stride_offset: PulseStrideOffset,
 ) -> DetectorTofData[RunType]:
@@ -631,7 +631,7 @@ def detector_time_of_flight_data(
 
 def monitor_time_of_flight_data(
     monitor_data: MonitorData[RunType, MonitorType],
-    lookup: TimeOfFlightLookupTable,
+    lookup: TimeOfFlightLookupTable[RunType],
     ltotal: MonitorLtotal[RunType, MonitorType],
     pulse_stride_offset: PulseStrideOffset,
 ) -> MonitorTofData[RunType, MonitorType]:

--- a/src/ess/reduce/time_of_flight/simulation.py
+++ b/src/ess/reduce/time_of_flight/simulation.py
@@ -7,7 +7,7 @@ import scippnexus as snx
 from scippneutron.chopper import DiskChopper
 
 from ..nexus.types import DiskChoppers, Position, RunType
-from .types import NumberOfSimulatedNeutrons, SimulationResults
+from .types import NumberOfSimulatedNeutrons, SimulatedNeutronEvents, SimulationResults
 
 
 def simulate_beamline(
@@ -18,7 +18,7 @@ def simulate_beamline(
     pulses: int = 1,
     seed: int | None = None,
     facility: str = 'ess',
-) -> SimulationResults:
+) -> SimulatedNeutronEvents:
     """
     Simulate a pulse of neutrons propagating through a chopper cascade using the
     ``tof`` package (https://tof.readthedocs.io).
@@ -62,7 +62,7 @@ def simulate_beamline(
     source = tof.Source(facility=facility, neutrons=neutrons, pulses=pulses, seed=seed)
     if not tof_choppers:
         events = source.data.squeeze().flatten(to='event')
-        return SimulationResults(
+        return SimulatedNeutronEvents(
             time_of_arrival=events.coords["birth_time"],
             speed=events.coords["speed"],
             wavelength=events.coords["wavelength"],
@@ -77,7 +77,7 @@ def simulate_beamline(
     events = events[
         ~(events.masks["blocked_by_others"] | events.masks["blocked_by_me"])
     ]
-    return SimulationResults(
+    return SimulatedNeutronEvents(
         time_of_arrival=events.coords["toa"],
         speed=events.coords["speed"],
         wavelength=events.coords["wavelength"],

--- a/src/ess/reduce/time_of_flight/simulation.py
+++ b/src/ess/reduce/time_of_flight/simulation.py
@@ -6,7 +6,7 @@ import scipp as sc
 import scippnexus as snx
 from scippneutron.chopper import DiskChopper
 
-from ..nexus.types import DiskChoppers, Position, SampleRun
+from ..nexus.types import DiskChoppers, Position, RunType
 from .types import NumberOfSimulatedNeutrons, SimulationResults
 
 
@@ -87,10 +87,10 @@ def simulate_beamline(
 
 
 def simulate_chopper_cascade_using_tof(
-    choppers: DiskChoppers[SampleRun],
+    choppers: DiskChoppers[RunType],
     neutrons: NumberOfSimulatedNeutrons,
-    source_position: Position[snx.NXsource, SampleRun],
-) -> SimulationResults:
+    source_position: Position[snx.NXsource, RunType],
+) -> SimulationResults[RunType]:
     """
     Simulate neutrons traveling through the chopper cascade using the ``tof`` package.
 
@@ -103,6 +103,8 @@ def simulate_chopper_cascade_using_tof(
     source_position:
         Position of the source.
     """
-    return simulate_beamline(
-        choppers=choppers, neutrons=neutrons, source_position=source_position
+    return SimulationResults[RunType](
+        simulate_beamline(
+            choppers=choppers, neutrons=neutrons, source_position=source_position
+        )
     )

--- a/src/ess/reduce/time_of_flight/types.py
+++ b/src/ess/reduce/time_of_flight/types.py
@@ -11,7 +11,7 @@ from ..nexus.types import MonitorType, RunType
 
 
 @dataclass
-class SimluatedNeutronEventList:
+class SimulatedNeutronEvents:
     """
     Results of a time-of-flight simulation used to create a lookup table.
 
@@ -47,7 +47,7 @@ class SimluatedNeutronEventList:
 
 
 class SimulationResults(
-    sciline.Scope[RunType, SimluatedNeutronEventList], SimluatedNeutronEventList
+    sl.Scope[RunType, SimulatedNeutronEvents], SimulatedNeutronEvents
 ):
     """
     Results of a time-of-flight simulation used to create a lookup table.
@@ -93,11 +93,11 @@ smaller if the pulse period is not an integer multiple of the time resolution.
 """
 
 
-class TimeOfFlightLookupTableFilename(sciline.Scope[RunType, str], str):
+class TimeOfFlightLookupTableFilename(sl.Scope[RunType, str], str):
     """Filename of the time-of-flight lookup table."""
 
 
-class TimeOfFlightLookupTable(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+class TimeOfFlightLookupTable(sl.Scope[RunType, sc.DataArray], sc.DataArray):
     """
     Lookup table giving time-of-flight as a function of distance and time of arrival.
     """

--- a/src/ess/reduce/time_of_flight/types.py
+++ b/src/ess/reduce/time_of_flight/types.py
@@ -11,7 +11,7 @@ from ..nexus.types import MonitorType, RunType
 
 
 @dataclass
-class SimulationResults:
+class SimluatedNeutronEventList:
     """
     Results of a time-of-flight simulation used to create a lookup table.
 
@@ -44,6 +44,14 @@ class SimulationResults:
     wavelength: sc.Variable
     weight: sc.Variable
     distance: sc.Variable
+
+
+class SimulationResults(
+    sciline.Scope[RunType, SimluatedNeutronEventList], SimluatedNeutronEventList
+):
+    """
+    Results of a time-of-flight simulation used to create a lookup table.
+    """
 
 
 NumberOfSimulatedNeutrons = NewType("NumberOfSimulatedNeutrons", int)
@@ -84,14 +92,16 @@ resolution in the lookup table will be at least the supplied value here, but may
 smaller if the pulse period is not an integer multiple of the time resolution.
 """
 
-TimeOfFlightLookupTableFilename = NewType("TimeOfFlightLookupTableFilename", str)
-"""Filename of the time-of-flight lookup table."""
+
+class TimeOfFlightLookupTableFilename(sciline.Scope[RunType, str], str):
+    """Filename of the time-of-flight lookup table."""
 
 
-TimeOfFlightLookupTable = NewType("TimeOfFlightLookupTable", sc.DataArray)
-"""
-Lookup table giving time-of-flight as a function of distance and time of arrival.
-"""
+class TimeOfFlightLookupTable(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """
+    Lookup table giving time-of-flight as a function of distance and time of arrival.
+    """
+
 
 LookupTableRelativeErrorThreshold = NewType("LookupTableRelativeErrorThreshold", float)
 """

--- a/src/ess/reduce/time_of_flight/workflow.py
+++ b/src/ess/reduce/time_of_flight/workflow.py
@@ -8,7 +8,7 @@ import scipp as sc
 
 from ..nexus import GenericNeXusWorkflow
 from . import eto_to_tof, simulation
-from .types import TimeOfFlightLookupTable, TimeOfFlightLookupTableFilename
+from .types import RunType, TimeOfFlightLookupTable, TimeOfFlightLookupTableFilename
 
 
 class TofLutProvider(Enum):
@@ -20,9 +20,9 @@ class TofLutProvider(Enum):
 
 
 def load_tof_lookup_table(
-    filename: TimeOfFlightLookupTableFilename,
-) -> TimeOfFlightLookupTable:
-    return TimeOfFlightLookupTable(sc.io.load_hdf5(filename))
+    filename: TimeOfFlightLookupTableFilename[RunType],
+) -> TimeOfFlightLookupTable[RunType]:
+    return TimeOfFlightLookupTable[RunType](sc.io.load_hdf5(filename))
 
 
 def GenericTofWorkflow(

--- a/tests/time_of_flight/unwrap_test.py
+++ b/tests/time_of_flight/unwrap_test.py
@@ -60,7 +60,7 @@ def _make_workflow_event_mode(
     )
 
     pl[DetectorData[SampleRun]] = mon
-    pl[time_of_flight.SimulationResults] = simulation
+    pl[time_of_flight.SimulationResults[SampleRun]] = simulation
     pl[time_of_flight.DetectorLtotal[SampleRun]] = distance
     pl[time_of_flight.LtotalRange] = distance, distance
     pl[time_of_flight.PulseStride] = pulse_stride
@@ -94,7 +94,7 @@ def _make_workflow_histogram_mode(
     )
 
     pl[DetectorData[SampleRun]] = mon
-    pl[time_of_flight.SimulationResults] = simulation
+    pl[time_of_flight.SimulationResults[SampleRun]] = simulation
     pl[time_of_flight.DetectorLtotal[SampleRun]] = distance
     pl[time_of_flight.LtotalRange] = distance, distance
     pl[time_of_flight.PulseStride] = pulse_stride
@@ -345,7 +345,7 @@ def test_pulse_skipping_unwrap_when_first_half_of_first_pulse_is_missing() -> No
     a = mon.group('event_time_zero')['event_time_zero', 1:]
     a.bins.coords['event_time_zero'] = sc.bins_like(a, a.coords['event_time_zero'])
     pl[DetectorData[SampleRun]] = a.bins.concat('event_time_zero')
-    pl[time_of_flight.SimulationResults] = sim
+    pl[time_of_flight.SimulationResults[SampleRun]] = sim
     pl[time_of_flight.DetectorLtotal[SampleRun]] = distance
     pl[time_of_flight.LtotalRange] = distance, distance
     pl[time_of_flight.PulseStride] = 2

--- a/tests/time_of_flight/wfm_test.py
+++ b/tests/time_of_flight/wfm_test.py
@@ -172,7 +172,7 @@ def test_dream_wfm(simulation_dream_choppers, ltotal, time_offset_unit, distance
 
     pl[DetectorData[SampleRun]] = raw
     pl[time_of_flight.DetectorLtotal[SampleRun]] = ltotal
-    pl[time_of_flight.SimulationResults] = simulation_dream_choppers
+    pl[time_of_flight.SimulationResults[SampleRun]] = simulation_dream_choppers
     pl[time_of_flight.LtotalRange] = ltotal.min(), ltotal.max()
 
     tofs = pl.compute(time_of_flight.DetectorTofData[SampleRun])
@@ -258,7 +258,9 @@ def test_dream_wfm_with_subframe_time_overlap(
     )
 
     pl[DetectorData[SampleRun]] = raw
-    pl[time_of_flight.SimulationResults] = simulation_dream_choppers_time_overlap
+    pl[time_of_flight.SimulationResults[SampleRun]] = (
+        simulation_dream_choppers_time_overlap
+    )
     pl[time_of_flight.DetectorLtotal[SampleRun]] = ltotal
     pl[time_of_flight.LtotalRange] = ltotal.min(), ltotal.max()
     pl[time_of_flight.LookupTableRelativeErrorThreshold] = 0.01
@@ -445,7 +447,7 @@ def test_v20_compute_wavelengths_from_wfm(
     )
 
     pl[DetectorData[SampleRun]] = raw
-    pl[time_of_flight.SimulationResults] = simulation_v20_choppers
+    pl[time_of_flight.SimulationResults[SampleRun]] = simulation_v20_choppers
     pl[time_of_flight.DetectorLtotal[SampleRun]] = ltotal
     pl[time_of_flight.LtotalRange] = ltotal.min(), ltotal.max()
 

--- a/tests/time_of_flight/workflow_test.py
+++ b/tests/time_of_flight/workflow_test.py
@@ -69,7 +69,7 @@ def test_GenericTofWorkflow_can_compute_tof_lut_without_nexus_file_or_detector_i
         sc.scalar(100.0, unit="m"),
     )
     wf[Position[snx.NXsource, SampleRun]] = fakes.source_position()
-    lut = wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    lut = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])
     assert isinstance(lut, sc.DataArray)
 
 
@@ -89,7 +89,7 @@ def test_GenericTofWorkflow_with_tof_lut_from_tof_simulation(
     _ = wf.compute(DetectorData[SampleRun])
     # LUT and Tof data cannot be computed without chopper and simulation params
     with pytest.raises(sciline.UnsatisfiedRequirement):
-        _ = wf.compute(time_of_flight.TimeOfFlightLookupTable)
+        _ = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])
     with pytest.raises(sciline.UnsatisfiedRequirement):
         _ = wf.compute(time_of_flight.DetectorTofData[SampleRun])
 
@@ -102,7 +102,7 @@ def test_GenericTofWorkflow_with_tof_lut_from_tof_simulation(
     wf[Position[snx.NXsource, SampleRun]] = fakes.source_position()
 
     # Should be able to compute DetectorData with chopper and simulation params
-    _ = wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    _ = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])
     detector = wf.compute(time_of_flight.DetectorTofData[SampleRun])
     assert 'tof' in detector.bins.coords
 
@@ -135,7 +135,7 @@ def test_GenericTofWorkflow_with_tof_lut_from_file(
         sc.scalar(100.0, unit="m"),
     )
     make_lut_wf[Position[snx.NXsource, SampleRun]] = fakes.source_position()
-    lut = make_lut_wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    lut = make_lut_wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])
     lut.save_hdf5(filename=tmp_path / "lut.h5")
 
     wf = GenericTofWorkflow(
@@ -145,11 +145,11 @@ def test_GenericTofWorkflow_with_tof_lut_from_file(
     )
     wf[CalibratedBeamline[SampleRun]] = calibrated_beamline
     wf[NeXusData[snx.NXdetector, SampleRun]] = nexus_data
-    wf[time_of_flight.TimeOfFlightLookupTableFilename] = (
+    wf[time_of_flight.TimeOfFlightLookupTableFilename[SampleRun]] = (
         tmp_path / "lut.h5"
     ).as_posix()
 
-    loaded_lut = wf.compute(time_of_flight.TimeOfFlightLookupTable)
+    loaded_lut = wf.compute(time_of_flight.TimeOfFlightLookupTable[SampleRun])
     assert_identical(lut, loaded_lut)
 
     detector = wf.compute(time_of_flight.DetectorTofData[SampleRun])


### PR DESCRIPTION
See discussion https://github.com/scipp/essimaging/pull/91#discussion_r2180018466 for context.

This should allow more flexible use of run types created in downstream packages, as opposed to only being able to use aliases of the types defined in `essreduce`.

Downside is that this is now a breaking change (again).

There were also other uses of `SampleRun` in the `live` submodule here, but I did not modify those, as I am unsure if it is required.