### PR TITLE
Add monitor normalization

### DIFF
--- a/src/ess/reduce/correction.py
+++ b/src/ess/reduce/correction.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Correction algorithms for neutron data reduction."""
+
+import scipp as sc
+
+from .uncertainty import UncertaintyBroadcastMode, broadcast_uncertainties
+
+
+def normalize_by_monitor_histogram(
+    detector: sc.DataArray,
+    *,
+    monitor: sc.DataArray,
+    uncertainty_broadcast_mode: UncertaintyBroadcastMode,
+) -> sc.DataArray:
+    """Normalize detector data by a histogrammed monitor.
+
+    First, the monitor is clipped to the range of the detector
+
+    .. math::
+
+        \\bar{m}_i = m_i I(x_i, x_{i+1}),
+
+    where :math:`m_i` is the monitor intensity in bin :math:`i`,
+    :math:`x_i` is the lower bin edge of bin :math:`i`, and
+    :math:`I(x_i, x_{i+1})` selects bins that are within the range of the detector.
+
+    The detector bins :math:`d_i` are normalized according to
+
+    .. math::
+
+        d_i^\\text{Norm} = \\frac{d_i}{\\bar{m}_i} \\Delta x_i
+        \\frac{\\sum_j\\,\\bar{m}_j}{\\sum_j\\,\\Delta x_j}
+
+    where :math:`\\Delta x_i` is the width of monitor bin :math:`i` (see below).
+    This normalization leads to a result that has the same
+    unit as the input detector data.
+
+    Monitor bin :math:`i` is chosen according to:
+
+    - *Histogrammed detector*: The monitor is
+      `rebinned <https://scipp.github.io/generated/functions/scipp.rebin.html>`_
+      to the detector binning. This distributes the monitor weights to the
+      detector bins.
+    - *Binned detector*: The monitor value for bin :math:`i` is determined via
+      :func:`scipp.lookup`. This means that for each event, the monitor value
+      is obtained from the monitor histogram at that event coordinate value.
+
+    This function is based on the implementation in
+    `NormaliseToMonitor <https://docs.mantidproject.org/nightly/algorithms/NormaliseToMonitor-v1.html>`_
+    of Mantid.
+
+    Parameters
+    ----------
+    detector:
+        Input detector data.
+        Must have a coordinate named ``monitor.dim``, that is, the single
+        dimension name of the monitor.
+    monitor:
+        A histogrammed monitor.
+        Must be one-dimensional and have a dimension coordinate, typically "wavelength".
+    uncertainty_broadcast_mode:
+        Choose how uncertainties of the monitor are broadcast to the sample data.
+
+    Returns
+    -------
+    :
+        ``detector`` normalized by ``monitor``.
+
+    See also
+    --------
+    normalize_by_monitor_integrated:
+        Normalize by an integrated monitor.
+    """
+    dim = monitor.dim
+
+    clipped = _clip_monitor_to_detector_range(monitor=monitor, detector=detector)
+    coord = clipped.coords[dim]
+    delta_w = coord[1:] - coord[:-1]
+    total_monitor_weight = broadcast_uncertainties(
+        clipped.sum() / delta_w.sum(),
+        prototype=clipped,
+        mode=uncertainty_broadcast_mode,
+    )
+    delta_w *= total_monitor_weight
+    norm = broadcast_uncertainties(
+        clipped / delta_w, prototype=detector, mode=uncertainty_broadcast_mode
+    )
+
+    if detector.bins is None:
+        return detector / norm
+    return detector.bins / sc.lookup(norm, dim=dim)
+
+
+def normalize_by_monitor_integrated(
+    detector: sc.DataArray,
+    *,
+    monitor: sc.DataArray,
+    uncertainty_broadcast_mode: UncertaintyBroadcastMode,
+) -> sc.DataArray:
+    """Normalize detector data by an integrated monitor.
+
+    The monitor is integrated according to
+
+    .. math::
+
+        M = \\sum_{i=0}^{N-1}\\, m_i (x_{i+1} - x_i) I(x_i, x_{i+1}),
+
+    where :math:`m_i` is the monitor intensity in bin :math:`i`,
+    :math:`x_i` is the lower bin edge of bin :math:`i`, and
+    :math:`I(x_i, x_{i+1})` selects bins that are within the range of the detector.
+
+    Parameters
+    ----------
+    detector:
+        Input detector data.
+    monitor:
+        A histogrammed monitor.
+        Must be one-dimensional and have a dimension coordinate, typically "wavelength".
+    uncertainty_broadcast_mode:
+        Choose how uncertainties of the monitor are broadcast to the sample data.
+
+    Returns
+    -------
+    :
+        `detector` normalized by a monitor.
+
+    See also
+    --------
+    normalize_by_monitor_histogram:
+        Normalize by a monitor histogram without integration.
+    """
+    clipped = _clip_monitor_to_detector_range(monitor=monitor, detector=detector)
+    coord = clipped.coords[clipped.dim]
+    norm = (clipped * (coord[1:] - coord[:-1])).data.sum()
+    norm = broadcast_uncertainties(
+        norm, prototype=detector, mode=uncertainty_broadcast_mode
+    )
+    return detector / norm
+
+
+def _clip_monitor_to_detector_range(
+    *, monitor: sc.DataArray, detector: sc.DataArray
+) -> sc.DataArray:
+    dim = monitor.dim
+    if not monitor.coords.is_edges(dim):
+        raise sc.CoordError(
+            f"Monitor coordinate '{dim}' must be bin-edges to integrate the monitor."
+        )
+
+    # Prefer a bin coord over an event coord because this makes the behavior for binned
+    # and histogrammed data consistent. If we used an event coord, we might allow a
+    # monitor range that is less than the detector bins which is fine for the vents,
+    # but would be wrong if the detector was subsequently histogrammed.
+    if dim in detector.coords:
+        det_coord = detector.coords[dim]
+
+        # Mask zero-count bins, which are an artifact from the rectangular 2-D binning.
+        # The wavelength of those bins must be excluded when determining the range.
+        if detector.bins is None:
+            mask = detector.data == sc.scalar(0.0, unit=detector.unit)
+        else:
+            mask = detector.data.bins.size() == sc.scalar(0.0, unit=None)
+        lo = (
+            sc.DataArray(det_coord[dim, :-1], masks={'zero_counts': mask}).nanmin().data
+        )
+        hi = sc.DataArray(det_coord[dim, 1:], masks={'zero_counts': mask}).nanmax().data
+
+    elif dim in detector.bins.coords:
+        det_coord = detector.bins.coords[dim]
+        # No need to mask here because we have the exact event coordinate values.
+        lo = det_coord.nanmin()
+        hi = det_coord.nanmax()
+
+    else:
+        raise sc.CoordError(
+            f"Missing '{dim}' coordinate in detector for monitor normalization."
+        )
+
+    if monitor.coords[dim].min() > lo or monitor.coords[dim].max() < hi:
+        raise ValueError(
+            f"Cannot normalize by monitor: The {dim} range of the monitor "
+            f"({monitor.coords[dim].min().value} to {monitor.coords[dim].max().value}) "
+            f"is smaller than the range of the detector ({lo.value} to {hi.value})."
+        )
+
+    if detector.bins is None:
+        # If we didn't rebin to the detector coord here, then, for a finer monitor
+        # binning than detector, the lookup table would extract one monitor value for
+        # each detector bin and ignore other values lying in the same detector bin.
+        # But integration would pick up all monitor bins.
+        return monitor.rebin({dim: det_coord})
+    return monitor[dim, lo:hi]

--- a/tests/correction_test.py
+++ b/tests/correction_test.py
@@ -1,0 +1,476 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+import pytest
+import scipp as sc
+import scipp.testing
+
+from ess.reduce.correction import (
+    normalize_by_monitor_histogram,
+    normalize_by_monitor_integrated,
+)
+from ess.reduce.uncertainty import UncertaintyBroadcastMode
+
+
+def test_normalize_by_monitor_histogram_aligned_bins_w_event_coord() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 44 / 3, 55 / 3], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å'))
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_aligned_bins_wo_event_coord() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 44 / 3, 55 / 3], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å'))
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_aligned_bins_hist() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[10, 30], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[44 / 3, 55 / 3], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_monitor_envelops_detector_bin() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 2.5], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[-1, 1.5, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 55 / 4, 165 / 8], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 2.5], unit='Å'))
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_monitor_envelops_detector_bin_hist() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[10, 30], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 2.5], unit='Å')},
+    )
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[-1, 1.5, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    # These values are different from the case with binned data in
+    # test_normalize_by_monitor_histogram_monitor_envelops_detector_bin
+    # because the monitor gets rebinned to match the detector bins.
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[11.2, 21.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 2.5], unit='Å')},
+    )
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_detector_envelops_monitor_bin() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 1.5, 3], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0, 2, 2.5], unit='Å')},
+    )
+    with pytest.raises(ValueError, match="smaller than the range of the detector"):
+        normalize_by_monitor_histogram(
+            detector,
+            monitor=monitor,
+            uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+        )
+
+
+def test_normalize_by_monitor_histogram_detector_envelops_monitor_bin_hist() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[10, 30], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 1.5, 3], unit='Å')},
+    )
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0, 2, 2.5], unit='Å')},
+    )
+    with pytest.raises(ValueError, match="smaller than the range of the detector"):
+        normalize_by_monitor_histogram(
+            detector,
+            monitor=monitor,
+            uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+        )
+
+
+def test_normalize_by_monitor_histogram_monitor_extra_bins_in_monitor() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[4.0, 5.0, 6.0, 7.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[-1.0, 0, 2, 3, 4], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 44 / 3, 55 / 3], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å'))
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_monitor_extra_bins_in_monitor_hist() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[10, 30], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[4.0, 5.0, 6.0, 7.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[-1.0, 0, 2, 3, 4], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[44 / 3, 55 / 3], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_monitor_extra_bins_in_detector() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[-10, 0, 10, 30, 40], unit='counts'),
+        coords={'w': sc.arange('w', -1.0, 4.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[-1.0, 0, 2, 3, 4], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0, 2, 3], unit='Å')},
+    )
+    with pytest.raises(ValueError, match="smaller than the range of the detector"):
+        normalize_by_monitor_histogram(
+            detector,
+            monitor=monitor,
+            uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+        )
+
+
+def test_normalize_by_monitor_histogram_monitor_finer_bins_in_detector() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 1, 2, 3], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 44 / 3, 55 / 3], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 1, 2, 3], unit='Å'))
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_monitor_finer_bins_in_detector_hist() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 1, 2, 3], unit='Å')},
+    )
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 44 / 3, 55 / 3], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 1, 2, 3], unit='Å')},
+    )
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_monitor_finer_bins_in_monitor() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 8.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 1, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 95 / 12, 95 / 3], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å'))
+
+    sc.testing.assert_allclose(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_monitor_finer_bins_in_monitor_hist() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[10, 30], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 8.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 1, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[380 / 39, 95 / 3], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[0.0, 2, 3], unit='Å')},
+    )
+
+    sc.testing.assert_allclose(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_zero_count_bins_are_ignored_hist() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30, 0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[-1.0, 0, 2, 3, 4], unit='Å')},
+    )
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[-0.5, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    # The monitor is rebinned to the detector bins, which introduces
+    # a 0/0 in the last bin.
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 11, 11, float('NaN')], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[-1.0, 0, 2, 3, 4], unit='Å')},
+    )
+
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_histogram_zero_count_bins_are_ignored() -> None:
+    detector = sc.DataArray(
+        sc.array(dims=['w'], values=[0, 10, 30], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[-1.0, 0, 2, 3, 4], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['w'], values=[5.0, 6.0], unit='counts'),
+        coords={'w': sc.array(dims=['w'], values=[-0.5, 2, 3], unit='Å')},
+    )
+    normalized = normalize_by_monitor_histogram(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['w'], values=[0.0, 110 / 7, 110 / 7], unit='counts'),
+        coords={'w': sc.arange('w', 3.0, unit='Å')},
+    ).bin(w=sc.array(dims=['w'], values=[-1.0, 0, 2, 3, 4], unit='Å'))
+
+    sc.testing.assert_allclose(normalized, expected)
+
+
+def test_normalize_by_monitor_integrated_expected_results() -> None:
+    detector = sc.DataArray(
+        sc.arange('wavelength', 1, 4, unit='counts'),
+        coords={'wavelength': sc.arange('wavelength', 3.0, unit='Å')},
+    ).bin(wavelength=sc.array(dims=['wavelength'], values=[0.0, 2, 3], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['wavelength'], values=[4.0, 5.0, 6.0], unit='counts'),
+        coords={
+            'wavelength': sc.array(
+                dims=['wavelength'], values=[0.0, 0.5, 2, 3], unit='Å'
+            )
+        },
+    )
+    normalized = normalize_by_monitor_integrated(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+    expected = detector / sc.scalar(4 * 0.5 + 5 * 1.5 + 6 * 1, unit='counts * Å')
+    sc.testing.assert_identical(normalized, expected)
+
+
+@pytest.mark.parametrize('event_coord', [True, False])
+def test_normalize_by_monitor_integrated_ignores_monitor_values_out_of_range(
+    event_coord: bool,
+) -> None:
+    detector = sc.DataArray(
+        sc.arange('wavelength', 4, unit='counts'),
+        coords={'wavelength': sc.arange('wavelength', 4.0, unit='Å')},
+    )
+    if event_coord:
+        # Make sure event at 3 is included
+        detector = detector.bin(
+            wavelength=sc.array(dims=['wavelength'], values=[0.0, 2, 3.1], unit='Å')
+        )
+        del detector.coords['wavelength']
+    else:
+        detector = detector.bin(
+            wavelength=sc.array(dims=['wavelength'], values=[0.0, 2, 3], unit='Å')
+        )
+        del detector.bins.coords['wavelength']
+    monitor = sc.DataArray(
+        sc.array(dims=['wavelength'], values=[4.0, 10.0], unit='counts'),
+        coords={
+            'wavelength': sc.array(dims=['wavelength'], values=[0.0, 3, 4], unit='Å')
+        },
+    )
+    normalized = normalize_by_monitor_integrated(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+    expected = detector / sc.scalar(4.0 * 3, unit='counts')
+    sc.testing.assert_identical(normalized, expected)
+
+
+@pytest.mark.parametrize('event_coord', [True, False])
+def test_normalize_by_monitor_integrated_uses_monitor_values_at_boundary(
+    event_coord: bool,
+) -> None:
+    detector = sc.DataArray(
+        sc.arange('wavelength', 4, unit='counts'),
+        coords={'wavelength': sc.arange('wavelength', 4.0, unit='Å')},
+    )
+    if event_coord:
+        # Make sure event at 3 is included
+        detector = detector.bin(
+            wavelength=sc.array(dims=['wavelength'], values=[0.0, 2, 3.1], unit='Å')
+        )
+        del detector.coords['wavelength']
+    else:
+        detector = detector.bin(
+            wavelength=sc.array(dims=['wavelength'], values=[0.0, 2, 3], unit='Å')
+        )
+        del detector.bins.coords['wavelength']
+    monitor = sc.DataArray(
+        sc.array(dims=['wavelength'], values=[4.0, 10.0], unit='counts'),
+        coords={
+            'wavelength': sc.array(dims=['wavelength'], values=[0.0, 2, 4], unit='Å')
+        },
+    )
+    normalized = normalize_by_monitor_integrated(
+        detector,
+        monitor=monitor,
+        uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+    )
+    expected = detector / sc.scalar(4.0 * 2 + 10.0 * 2, unit='counts')
+    sc.testing.assert_identical(normalized, expected)
+
+
+def test_normalize_by_monitor_integrated_raises_if_monitor_range_too_narrow() -> None:
+    detector = sc.DataArray(
+        sc.arange('wavelength', 3, unit='counts'),
+        coords={'wavelength': sc.arange('wavelength', 3.0, unit='Å')},
+    ).bin(wavelength=sc.array(dims=['wavelength'], values=[0.0, 2, 3], unit='Å'))
+    monitor = sc.DataArray(
+        sc.array(dims=['wavelength'], values=[4.0, 10.0], unit='counts'),
+        coords={
+            'wavelength': sc.array(dims=['wavelength'], values=[1.0, 3, 4], unit='Å')
+        },
+    )
+    with pytest.raises(ValueError, match="smaller than the range of the detector"):
+        normalize_by_monitor_integrated(
+            detector,
+            monitor=monitor,
+            uncertainty_broadcast_mode=UncertaintyBroadcastMode.fail,
+        )


### PR DESCRIPTION
This addresses https://github.com/scipp/essdiffraction/issues/167

I moved the code here because it is rather involved and it will be needed by spectroscopy and reflectometry as well. Once this is merged, I will prepare a PR in ESSdiffraction to use these new implementations.

Note that I changed the behaviour. The code now favours bin coordinates over event coordinates when selecting the monitor range. Here is an example why: Let's say we have detector data where the last event is at 1.9Å but the last bin ends at 2Å. And we have a monitor with data up to 1.91Å. If we check ranges based on events, we would be allowed to normalize. But if we histogrammed after normalization, we would get a detector bin that extends to 2Å even though we only have normalization data for part of this bin. The chosen implementation avoids this problem. In practice this probably does not matter because bin widths should be small enough to limit detector bins to be within the monitor range.

Further, for histogrammed detectors, the monitor is now rebinned to match the detector instead of using `lookup`. This assigns more accurate weights to each bin. And, AFAIK, this matches Mantid.