### PR TITLE
Cache paths in Pooch

### DIFF
--- a/src/ess/reduce/data.py
+++ b/src/ess/reduce/data.py
@@ -15,7 +15,13 @@ class Registry:
     is not a hard dependency of ESSreduce and needs to be installed separately.
     """
 
-    def __init__(self, instrument: str, files: dict[str, str], version: str) -> None:
+    def __init__(
+        self,
+        instrument: str,
+        files: dict[str, str],
+        version: str,
+        retry_if_failed: int = 3,
+    ) -> None:
         import pooch
 
         self._registry = pooch.create(
@@ -25,7 +31,7 @@ class Registry:
             + '{version}/',
             version=version,
             registry=files,
-            retry_if_failed=3,
+            retry_if_failed=retry_if_failed,
         )
         self._unzip_processor = pooch.Unzip()
 

--- a/src/ess/reduce/data.py
+++ b/src/ess/reduce/data.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+from pathlib import Path
 
 
 class Registry:
@@ -29,7 +31,7 @@ class Registry:
         """Return True if the key is in the registry."""
         return key in self._registry.registry
 
-    def get_path(self, name: str, unzip: bool = False) -> str:
+    def get_path(self, name: str, unzip: bool = False) -> Path:
         """
         Get the path to a file in the registry.
 
@@ -45,8 +47,10 @@ class Registry:
         :
             The Path to the file.
         """
-        return self._registry.fetch(
-            name, processor=self._unzip_processor if unzip else None
+        return Path(
+            self._registry.fetch(
+                name, processor=self._unzip_processor if unzip else None
+            )
         )
 
 
@@ -94,37 +98,37 @@ _loki_registry = Registry(
 )
 
 
-def bifrost_simulated_elastic() -> str:
+def bifrost_simulated_elastic() -> Path:
     """McStas simulation with elastic incoherent scattering + phonon."""
     return _bifrost_registry.get_path('BIFROST_20240914T053723.h5')
 
 
-def loki_tutorial_sample_run_60250() -> str:
+def loki_tutorial_sample_run_60250() -> Path:
     """Sample run with sample and sample holder/can, no transmission monitor in beam."""
     return _loki_registry.get_path('60250-2022-02-28_2215.nxs')
 
 
-def loki_tutorial_sample_run_60339() -> str:
+def loki_tutorial_sample_run_60339() -> Path:
     """Sample run with sample and sample holder/can, no transmission monitor in beam."""
     return _loki_registry.get_path('60339-2022-02-28_2215.nxs')
 
 
-def loki_tutorial_background_run_60248() -> str:
+def loki_tutorial_background_run_60248() -> Path:
     """Background run with sample holder/can only, no transmission monitor."""
     return _loki_registry.get_path('60248-2022-02-28_2215.nxs')
 
 
-def loki_tutorial_background_run_60393() -> str:
+def loki_tutorial_background_run_60393() -> Path:
     """Background run with sample holder/can only, no transmission monitor."""
     return _loki_registry.get_path('60393-2022-02-28_2215.nxs')
 
 
-def loki_tutorial_sample_transmission_run() -> str:
+def loki_tutorial_sample_transmission_run() -> Path:
     """Sample transmission run (sample + sample holder/can + transmission monitor)."""
     return _loki_registry.get_path('60394-2022-02-28_2215.nxs')
 
 
-def dream_coda_test_file() -> str:
+def dream_coda_test_file() -> Path:
     """CODA file for DREAM where most pulses have been removed.
 
     See ``tools/shrink_nexus.py``.

--- a/src/ess/reduce/data.py
+++ b/src/ess/reduce/data.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Data files bundled with ESSreduce."""
 
 from functools import cache
 from pathlib import Path

--- a/src/ess/reduce/data.py
+++ b/src/ess/reduce/data.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 
+from functools import cache
 from pathlib import Path
 
 
@@ -31,9 +32,19 @@ class Registry:
         """Return True if the key is in the registry."""
         return key in self._registry.registry
 
+    @cache  # noqa: B019
     def get_path(self, name: str, unzip: bool = False) -> Path:
-        """
-        Get the path to a file in the registry.
+        """Get the path to a file in the registry.
+
+        Downloads the file if necessary.
+
+        Note that return values of this method are cached to avoid recomputing
+        potentially expensive checksums.
+        This usually means that the ``Registry`` object itself gets stored until the
+        Python interpreter shuts down.
+        However, registries are small and do not own resources.
+        It is anyway expected that the registry objects are stored at
+        module scope and live until program exit.
 
         Parameters
         ----------


### PR DESCRIPTION
The main change here is the addition of `@cache` in `get_path`. See https://github.com/scipp/esssans/pull/206.

I decided to put this into ESSreduce to allow the instrument packages to take advantage of it. It would be nice to place it further upstream but I don't see a good package for it. And the performance impact is most relevant for the instrument packages because they rely more on data files for their tests.