### PR TITLE
Extend public interface of nexus loader

### DIFF
--- a/src/ess/reduce/nexus/__init__.py
+++ b/src/ess/reduce/nexus/__init__.py
@@ -20,6 +20,7 @@ from ._nexus_loader import (
     load_all_components,
     load_component,
     load_data,
+    open_component_group,
     open_nexus_file,
 )
 from .workflow import GenericNeXusWorkflow
@@ -32,6 +33,7 @@ __all__ = [
     'load_all_components',
     'load_component',
     'load_data',
+    'open_component_group',
     'open_nexus_file',
     'types',
 ]


### PR DESCRIPTION
This makes some more functions public and adds `open_component_group`. These functions are already used in spectroscopy and reflectometry and this changes allows us to use exclusively public functions.

See
- https://github.com/scipp/essreflectometry/pull/180
- https://github.com/scipp/essspectroscopy/pull/73