### PR TITLE
Load data from NXlog in detectors

### DIFF
--- a/src/ess/reduce/nexus/_nexus_loader.py
+++ b/src/ess/reduce/nexus/_nexus_loader.py
@@ -469,6 +469,9 @@ def load_data(
         elif _contains_nx_class(component, snx.NXdata):
             data = _unique_child_group(component, snx.NXdata, None)
             sel = _to_snx_selection(selection, for_events=False)
+        elif _contains_nx_class(component, snx.NXlog):
+            data = _unique_child_group(component, snx.NXlog, "data")
+            sel = _to_snx_selection(selection, for_events=False)
         else:
             raise ValueError(
                 f"NeXus group '{component.name}' contains neither "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,17 @@ def loki_registry() -> Registry:
 
 
 @pytest.fixture(scope='session')
+def tbl_registry() -> Registry:
+    return make_registry(
+        'ess/tbl',
+        files={
+            "857127_00000112_small.hdf": "md5:6f3059e0e5e111a2a8f1b368f24c6f93",
+        },
+        version='1',
+    )
+
+
+@pytest.fixture(scope='session')
 def bifrost_simulated_elastic(bifrost_registry: Registry) -> Path:
     """McStas simulation with elastic incoherent scattering + phonon."""
     return bifrost_registry.get_path('BIFROST_20240914T053723.h5')
@@ -101,3 +112,9 @@ def dream_coda_test_file(dream_registry: Registry) -> Path:
     See ``tools/shrink_nexus.py``.
     """
     return dream_registry.get_path('TEST_977695_00068064.hdf')
+
+
+@pytest.fixture(scope='session')
+def tbl_commissioning_orca_file(tbl_registry: Registry) -> Path:
+    """TBL file from cold commissioning with the ORCA detector."""
+    return tbl_registry.get_path('857127_00000112_small.hdf')

--- a/tests/nexus/nexus_loader_test.py
+++ b/tests/nexus/nexus_loader_test.py
@@ -270,6 +270,18 @@ def test_load_data_loads_expected_histogram_data(nexus_file, expected_monitor):
     sc.testing.assert_identical(histogram, expected_monitor)
 
 
+def test_load_data_loads_expected_histogram_data_from_nxlog(
+    tbl_commissioning_orca_file: Path,
+):
+    histogram = nexus.load_data(
+        tbl_commissioning_orca_file,
+        component_name=nexus.types.NeXusDetectorName('orca_detector'),
+    )
+    assert histogram.ndim == 3
+    assert histogram.sizes['time'] == 13
+    assert 'time' in histogram.coords
+
+
 @pytest.mark.parametrize('entry_name', [None, nexus.types.NeXusEntryName('entry-001')])
 @pytest.mark.parametrize(
     'selection',


### PR DESCRIPTION
The ORCA detector is saved as an NXlog within an NXdetector because it has a time-dimension.