### PR TITLE
Fix dream wfm tests

### DIFF
--- a/tests/time_of_flight/wfm_test.py
+++ b/tests/time_of_flight/wfm_test.py
@@ -206,7 +206,7 @@ def test_dream_wfm(
             (x.coords["wavelength"] - ref.coords["wavelength"])
             / ref.coords["wavelength"]
         )
-        assert np.nanpercentile(diff.values, 100) < 0.02
+        assert np.nanpercentile(diff.values, 99.9) < 0.02
         assert sc.isclose(ref.data.sum(), da.data.sum(), rtol=sc.scalar(1.0e-3))
 
 
@@ -292,7 +292,7 @@ def test_dream_wfm_with_subframe_time_overlap(
         sel = sc.isfinite(x.coords["wavelength"])
         y = ref.coords["wavelength"][sel]
         diff = abs((x.coords["wavelength"][sel] - y) / y)
-        assert np.nanpercentile(diff.values, 100) < 0.02
+        assert np.nanpercentile(diff.values, 99.9) < 0.02
         sum_wfm = da.hist(wavelength=100).data.sum()
         sum_ref = ref.hist(wavelength=100).data.sum()
         # Verify that we lost some neutrons that were in the overlapping region


### PR DESCRIPTION
With the latest release of `tof`, the nightly tests started failing.
It turns out that when computing the wavelengths of neutrons, there was a chance of less than 1 in 10,000 to have some outliers where the error is greater than 2%.

Here is a figure of the error of each neutron in the test, using 100K neutrons. We see 5 outliers.
<img width="600" height="400" alt="Figure 1 (64)" src="https://github.com/user-attachments/assets/24862aa3-0350-4186-a8c0-82ebf4bda0f6" />

I checked and even with the previous version of `tof`, if we use more neutrons than the 10K used in the test, we also start to see the outliers. So it is just a statistical fluctuation and we were simply lucky not to see it before.

To fix, we relax the percentile threshold by a very small amount (100 -> 99.9) to make the test more robust to future changes.