### PR TITLE
Flat detector viewer

### DIFF
--- a/src/ess/reduce/tools/__init__.py
+++ b/src/ess/reduce/tools/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+from .flat_detector_viewer import FlatDetectorViewer
+
+__all__ = ["FlatDetectorViewer"]

--- a/src/ess/reduce/tools/flat_detector_viewer.py
+++ b/src/ess/reduce/tools/flat_detector_viewer.py
@@ -133,16 +133,12 @@ class _DimensionSelector(ipw.VBox):
 
     def set_dims(self, new_dims: tuple[str, ...], h_dim: str, v_dim: str) -> None:
         options = {dim.capitalize(): dim for dim in new_dims}
-        old_h = self._horizontal_buttons.value
-        old_v = self._vertical_buttons.value
         if self._horizontal_buttons.options != options:
             self._lock = True
             self._horizontal_buttons.options = options
             self._vertical_buttons.options = options
-            if old_h not in new_dims:
-                self._horizontal_buttons.value = h_dim
-            if old_v not in new_dims:
-                self._vertical_buttons.value = v_dim
+            self._horizontal_buttons.value = h_dim
+            self._vertical_buttons.value = v_dim
             self._lock = False
 
     @property


### PR DESCRIPTION
Add a generic version of the Dream [FlatVoxelViewer](https://github.com/scipp/essdiffraction/blob/main/src/ess/dream/diagnostics.py#L19) so it can be used by other instruments.

The Dream voxel viewer can then be replaced by:
```Py
from ess.reduce.tools.flat_detector_viewer import FlatDetectorViewer

FlatDetectorViewer(dg, horizontal_dim="module", vertical_dim="segment")
```