### PR TITLE
Propagate context values to finalize workflow

### DIFF
--- a/src/ess/reduce/streaming.py
+++ b/src/ess/reduce/streaming.py
@@ -430,6 +430,9 @@ class StreamProcessor:
             needs_recompute |= self._context_key_to_cached_context_nodes_map[key]
         for key, value in context.items():
             self._context_workflow[key] = value
+            # Propagate context values to finalize workflow so providers that depend
+            # on context keys receive the updated values during finalize().
+            self._finalize_workflow[key] = value
         results = self._context_workflow.compute(needs_recompute)
         for key, value in results.items():
             if key in self._target_keys:


### PR DESCRIPTION
## Summary

- Ensure context keys are available to providers that run during `finalize()` and depend directly on context values
- Previously, context values were only propagated to the context workflow for computing intermediate results, but finalize-time providers not depending on accumulated values could not access raw context keys

## Test plan

- Added `test_StreamProcessor_finalize_provider_uses_context_directly` which verifies the fix
- Test fails without the fix, passes with it
- All 30 streaming tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)